### PR TITLE
Added ViewStream and OutputPanel.

### DIFF
--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -1,2 +1,3 @@
 from .view_buffer import ViewBuffer
 from .view_stream import ViewStream
+from .output_panel import OutputPanel

--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -1,1 +1,1 @@
-# This space intentionally left blank
+from .view_stream import ViewStream

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -1,0 +1,23 @@
+import sublime
+
+from .view_stream import ViewStream
+
+class OutputPanel(ViewStream):
+    def __init__(self, window, name):
+        super().__init__(window.get_output_panel(name))
+
+        self.window = window
+        self.name = name
+
+    @property
+    def full_name(self):
+        return "output.%s" % self.name
+
+    def show(self):
+        self.window.run_command("show_panel", { "panel": self.full_name })
+
+    def hide(self):
+        self.window.run_command("hide_panel", { "panel": self.full_name })
+
+    def destroy(self):
+        self.window.destroy_output_panel(self.name)

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -14,9 +14,11 @@ class OutputPanel(ViewStream):
         return "output.%s" % self.name
 
     def show(self):
+        self._check_is_valid()
         self.window.run_command("show_panel", { "panel": self.full_name })
 
     def hide(self):
+        self._check_is_valid()
         self.window.run_command("hide_panel", { "panel": self.full_name })
 
     def destroy(self):

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -6,10 +6,17 @@ class ViewStream():
         self.view = view
 
     def _check_selection(self):
+        if len(self.view.sel()) == 0:
+            raise ValueError("The underlying view has no selection.")
         if len(self.view.sel()) > 1:
             raise ValueError("The underlying view has multiple selections.")
 
+    def _check_is_valid(self):
+        if not self.view.is_valid():
+            raise ValueError("The underlying view is invalid.")
+
     def write(self, s):
+        self._check_is_valid()
         self._check_selection()
         self.view.run_command('insert', { 'characters': s })
         return len(s)
@@ -21,6 +28,7 @@ class ViewStream():
         pass
 
     def seek(self, index, whence=SEEK_SET):
+        self._check_is_valid()
         if whence == SEEK_SET:
             selection = self.view.sel()
             selection.clear()
@@ -41,5 +49,6 @@ class ViewStream():
         self.seek(self.view.size())
 
     def clear(self):
+        self._check_is_valid()
         self.view.run_command('select_all')
         self.view.run_command('left_delete')

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -5,7 +5,12 @@ class ViewStream():
     def __init__(self, view):
         self.view = view
 
+    def _check_selection(self):
+        if len(self.view.sel()) > 1:
+            raise ValueError("The underlying view has multiple selections.")
+
     def write(self, s):
+        self._check_selection()
         self.view.run_command('insert', { 'characters': s })
         return len(s)
 

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -1,4 +1,5 @@
 from sublime import Region
+from io import SEEK_SET, SEEK_CUR, SEEK_END
 
 class ViewStream():
     def __init__(self, view):
@@ -14,10 +15,19 @@ class ViewStream():
     def flush(self):
         pass
 
-    def seek(self, index):
-        selection = self.view.sel()
-        selection.clear()
-        selection.add(Region(index))
+    def seek(self, index, whence=SEEK_SET):
+        if whence == SEEK_SET:
+            selection = self.view.sel()
+            selection.clear()
+            selection.add(Region(index))
+        elif whence == SEEK_CUR:
+            if index != 0: raise TypeError('Argument "index" must be zero when "whence" is io.SEEK_CUR.')
+            pass # Do nothing.
+        elif whence == SEEK_END:
+            if index != 0: raise TypeError('Argument "index" must be zero when "whence" is io.SEEK_END.')
+            self.seek(self.view.size())
+        else:
+            raise TypeError('Invalid value for argument "whence".')
 
     def seek_start(self):
         self.seek(0)

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -1,0 +1,30 @@
+from sublime import Region
+
+class ViewStream():
+    def __init__(self, view):
+        self.view = view
+
+    def write(self, s):
+        self.view.run_command('insert', { 'characters': s })
+        return len(s)
+
+    def print(self, *objects, **kwargs):
+        print(*objects, file=self, **kwargs)
+
+    def flush(self):
+        pass
+
+    def seek(self, index):
+        selection = self.view.sel()
+        selection.clear()
+        selection.add(Region(index))
+
+    def seek_start(self):
+        self.seek(0)
+
+    def seek_end(self):
+        self.seek(self.view.size())
+
+    def clear(self):
+        self.view.run_command('select_all')
+        self.view.run_command('left_delete')

--- a/tests/test_output_panel.py
+++ b/tests/test_output_panel.py
@@ -1,0 +1,58 @@
+import sublime
+from sublime_lib import OutputPanel
+
+from unittest import TestCase
+
+class TestOutputPanel(TestCase):
+
+    def setUp(self):
+        self.window = sublime.active_window()
+        self.panel_name = "test_panel"
+        self.panel = OutputPanel(self.window, self.panel_name)
+        self.panel.show()
+
+    def tearDown(self):
+        self.panel.destroy()
+
+    def assertContents(self, text):
+        view = self.panel.view
+        self.assertEqual(
+            view.substr(sublime.Region(0, view.size())),
+            text
+        )
+
+    def test_stream_operations(self):
+        self.panel.write("Hello, ")
+        self.panel.print("World!")
+        
+        self.panel.seek_start()
+        self.panel.print("Top")
+
+        self.panel.seek_end()
+        self.panel.print("Bottom")
+
+        self.panel.seek(4)
+        self.panel.print("After Top")
+
+        self.assertContents("Top\nAfter Top\nHello, World!\nBottom\n")
+
+    def test_clear(self):
+        self.panel.write("Some text")
+        self.panel.clear()
+        self.assertContents("")
+
+    def test_show_hide(self):
+        self.panel.show()
+
+        self.assertEqual(self.window.active_panel(), self.panel.full_name)
+
+        self.panel.hide()
+
+        self.assertNotEqual(self.window.active_panel(), self.panel.full_name)
+
+    def test_exists(self):
+        self.assertIsNotNone(self.window.find_output_panel(self.panel.name))
+
+    def test_destroy(self):
+        self.panel.destroy()
+        self.assertIsNone(self.window.find_output_panel(self.panel.name))

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -1,0 +1,42 @@
+import sublime
+from sublime_lib import ViewStream
+
+from unittest import TestCase
+
+class TestViewStream(TestCase):
+
+    def setUp(self):
+        self.view = sublime.active_window().new_file()
+        self.stream = ViewStream(self.view)
+
+    def tearDown(self):
+        if self.view:
+            self.view.set_scratch(True)
+            self.view.window().focus_view(self.view)
+            self.view.window().run_command("close_file")
+
+    def assertContents(self, text):
+        self.assertEqual(
+            self.view.substr(sublime.Region(0, self.view.size())),
+            text
+        )
+
+    def test_stream_operations(self):
+        self.stream.write("Hello, ")
+        self.stream.print("World!")
+        
+        self.stream.seek_start()
+        self.stream.print("Top")
+
+        self.stream.seek_end()
+        self.stream.print("Bottom")
+
+        self.stream.seek(4)
+        self.stream.print("After Top")
+
+        self.assertContents("Top\nAfter Top\nHello, World!\nBottom\n")
+
+    def test_clear(self):
+        self.stream.write("Some text")
+        self.stream.clear()
+        self.assertContents("")


### PR DESCRIPTION
Discussed briefly in #3.

Notes:

- `write` and `flush` constitute the informal stream interface. `flush` is, of course, a no-op. (I don't think there's any reason to do any buffering here.)
- `print` is a convenience method: `stream.print(foo)` rather than `print(foo, file=stream)`. It might be appropriate to throw a `TypeError` if the user passes a `file` argument.
- The behavior of `seek_start` is used in the `finish` method of the existing `OutputPanel` implementation. Because it is purely a view operation, I thought it made sense to implement at this lower level. `seek_end` and `seek` make sense in combination with `seek_start`.
- `clear` uses two commands, which could cause flickering in some extreme cases. However, the only workaround is creating a new command, which would require a workaround of its own to get working in a dependency. I don't feel that it's worth the complication, myself.