### PR TITLE
Added "fancy settings" with bracket access and better subscription.

### DIFF
--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -1,1 +1,1 @@
-# This space intentionally left blank
+from .fancy_settings import FancySettings

--- a/st3/sublime_lib/fancy_settings.py
+++ b/st3/sublime_lib/fancy_settings.py
@@ -1,0 +1,47 @@
+class FancySettings():
+    def __init__(self, settings):
+        self.settings = settings
+
+    def get(self, name, default=None):
+        return self.settings.get(name, default)
+
+    def set(self, name, value):
+        self.settings.set(name, value)
+
+    def erase(self, name):
+        self.settings.erase(name)
+
+    def has(self, name):
+        return self.settings.has(name)
+
+    def __getitem__(self, key):
+        return self.get(key)
+
+    def __setitem__(self, key, value):
+        self.set(key, value)
+
+    def __delitem__(self, key):
+        self.erase(key)
+
+    def __contains__(self, item):
+        return self.has(item)
+
+    def subscribe(self, key, selector, callback):
+        if isinstance(selector, str):
+            key = selector
+            selector = lambda this: this[key]
+
+        previous_value = selector(self)
+
+        def onchange():
+            nonlocal previous_value
+            new_value = selector(self)
+
+            if new_value != previous_value:
+                callback(new_value, previous_value)
+                previous_value = new_value
+
+        self.settings.add_on_change(key, onchange)
+
+    def unsubscribe(self, key):
+        self.settings.clear_on_change(key)

--- a/st3/sublime_lib/fancy_settings.py
+++ b/st3/sublime_lib/fancy_settings.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 def isiterable(obj):
     try:
         iter(obj)
@@ -40,7 +42,7 @@ class FancySettings():
     def __contains__(self, item):
         return self.has(item)
 
-    def subscribe(self, key, selector, callback):
+    def subscribe(self, selector, callback):
         if callable(selector):
             selector_fn = selector
         elif isinstance(selector, str):
@@ -60,7 +62,9 @@ class FancySettings():
                 callback(new_value, previous_value)
                 previous_value = new_value
 
+        key = str(uuid4())
         self.settings.add_on_change(key, onchange)
+        return key
 
     def unsubscribe(self, key):
         self.settings.clear_on_change(key)

--- a/st3/sublime_lib/fancy_settings.py
+++ b/st3/sublime_lib/fancy_settings.py
@@ -8,17 +8,17 @@ def isiterable(obj):
         return False
 
 class FancySettings():
-    def __init__(self, settings):
+    def __init__(self, settings, defaults={}):
         self.settings = settings
+        self.defaults = defaults
 
     def get(self, name, default=ARGUMENT_NOT_GIVEN):
-        if default is ARGUMENT_NOT_GIVEN:
-            if self.settings.has(name):
-                return self.settings.get(name)
-            else:
-                raise KeyError(name)
+        if self.settings.has(name):
+            return self.settings.get(name)
+        elif default is not ARGUMENT_NOT_GIVEN:
+            return self.defaults.get(name, default)
         else:
-            return self.settings.get(name, default)
+            return self.defaults.get(name)
 
     def set(self, name, value):
         self.settings.set(name, value)

--- a/st3/sublime_lib/fancy_settings.py
+++ b/st3/sublime_lib/fancy_settings.py
@@ -45,19 +45,22 @@ class FancySettings():
         else:
             return default
 
-    def setdefault(key, default=None):
+    def setdefault(self, key, default=None):
         if key in self:
             return self.get(key)
         else:
             self.set(key, default)
             return default
 
-    def update(*pairs, **kwargs):
-        for key, value in pairs:
-            self.set(key, value)
+    def update(self, other=[], **kwargs):
+        if isinstance(other, dict):
+            other = other.items()
+
+        for key, value in other:
+            self[key] = value
 
         for key, value in kwargs.items():
-            self.set(key, value)
+            self[key] = value
 
     def subscribe(self, selector, callback, default_value=None):
         if callable(selector):

--- a/st3/sublime_lib/fancy_settings.py
+++ b/st3/sublime_lib/fancy_settings.py
@@ -7,25 +7,44 @@ def isiterable(obj):
     except TypeError:
         return False
 
+NOT_GIVEN = {}
+
 class FancySettings():
     def __init__(self, settings, defaults={}):
         self.settings = settings
         self.defaults = defaults
 
-    def get(self, name, default=None):
-        return self.settings.get(name, self.defaults.get(default))
+    def get(self, key, default=None):
+        return self.settings.get(key, self.defaults.get(key, default))
 
-    def set(self, name, value):
-        self.settings.set(name, value)
+    def set(self, key, value):
+        self.settings.set(key, value)
 
-    def erase(self, name):
-        self.settings.erase(name)
+    def erase(self, key):
+        self.settings.erase(key)
 
-    def has(self, name):
-        return self.settings.has(name)
+    def has(self, key):
+        return self.settings.has(key)
+
+    def pop(self, key, default=NOT_GIVEN):
+        if key in self:
+            ret = self.get(key)
+            self.erase(key)
+            return ret
+        elif default is NOT_GIVEN:
+            raise KeyError(key)
+        else:
+            return default
+
+    def setdefault(key, default=None):
+        if key in self:
+            return self.get(key)
+        else:
+            self.set(key, default)
+            return default
 
     def __getitem__(self, key):
-        if self.settings.has(key) or key in self.defaults:
+        if key in self or key in self.defaults:
             return self.get(key)
         else:
             raise KeyError(key)
@@ -41,6 +60,13 @@ class FancySettings():
 
     def __contains__(self, item):
         return self.has(item)
+
+    def update(*pairs, **kwargs):
+        for key, value in pairs:
+            self.set(key, value)
+
+        for key, value in kwargs.items():
+            self.set(key, value)
 
     def subscribe(self, selector, callback, default_value=None):
         if callable(selector):

--- a/st3/sublime_lib/fancy_settings.py
+++ b/st3/sublime_lib/fancy_settings.py
@@ -1,4 +1,5 @@
 from uuid import uuid4
+from collections.abc import Mapping
 
 def isiterable(obj):
     try:
@@ -6,6 +7,9 @@ def isiterable(obj):
         return True
     except TypeError:
         return False
+
+def ismapping(obj):
+    return isinstance(obj, Mapping)
 
 NOT_GIVEN = {}
 
@@ -24,10 +28,10 @@ class FancySettings():
         self.settings.set(key, value)
 
     def __delitem__(self, key):
-        if self.has(name):
-            self.settings.erase(name)
+        if key in self:
+            self.settings.erase(key)
         else:
-            raise KeyError(name)
+            raise KeyError(key)
 
     def __contains__(self, item):
         return self.settings.has(item)
@@ -37,8 +41,8 @@ class FancySettings():
 
     def pop(self, key, default=NOT_GIVEN):
         if key in self:
-            ret = self.get(key)
-            self.erase(key)
+            ret = self[key]
+            del self[key]
             return ret
         elif default is NOT_GIVEN:
             raise KeyError(key)
@@ -47,13 +51,13 @@ class FancySettings():
 
     def setdefault(self, key, default=None):
         if key in self:
-            return self.get(key)
+            return self[key]
         else:
-            self.set(key, default)
+            self[key] = default
             return default
 
     def update(self, other=[], **kwargs):
-        if isinstance(other, dict):
+        if ismapping(other):
             other = other.items()
 
         for key, value in other:

--- a/st3/sublime_lib/fancy_settings.py
+++ b/st3/sublime_lib/fancy_settings.py
@@ -1,5 +1,3 @@
-ARGUMENT_NOT_GIVEN = {}
-
 def isiterable(obj):
     try:
         iter(obj)
@@ -12,34 +10,32 @@ class FancySettings():
         self.settings = settings
         self.defaults = defaults
 
-    def get(self, name, default=ARGUMENT_NOT_GIVEN):
-        if self.settings.has(name):
-            return self.settings.get(name)
-        elif default is not ARGUMENT_NOT_GIVEN:
-            return self.defaults.get(name, default)
-        else:
-            return self.defaults.get(name)
+    def get(self, name, default=None):
+        return self.settings.get(name, self.defaults.get(default))
 
     def set(self, name, value):
         self.settings.set(name, value)
 
     def erase(self, name):
-        if self.settings.has(name):
-            self.settings.erase(name)
-        else:
-            raise KeyError(name)
+        self.settings.erase(name)
 
     def has(self, name):
         return self.settings.has(name)
 
     def __getitem__(self, key):
-        return self.get(key)
+        if self.settings.has(key) or self.defaults.has(key):
+            return self.get(key)
+        else:
+            raise KeyError(name)
 
     def __setitem__(self, key, value):
         self.set(key, value)
 
     def __delitem__(self, key):
-        self.erase(key)
+        if self.has(name):
+            self.erase(name)
+        else:
+            raise KeyError(name)
 
     def __contains__(self, item):
         return self.has(item)

--- a/st3/sublime_lib/fancy_settings.py
+++ b/st3/sublime_lib/fancy_settings.py
@@ -25,10 +25,10 @@ class FancySettings():
         return self.settings.has(name)
 
     def __getitem__(self, key):
-        if self.settings.has(key) or self.defaults.has(key):
+        if self.settings.has(key) or key in self.defaults:
             return self.get(key)
         else:
-            raise KeyError(name)
+            raise KeyError(key)
 
     def __setitem__(self, key, value):
         self.set(key, value)
@@ -42,11 +42,11 @@ class FancySettings():
     def __contains__(self, item):
         return self.has(item)
 
-    def subscribe(self, selector, callback):
+    def subscribe(self, selector, callback, default_value=None):
         if callable(selector):
             selector_fn = selector
         elif isinstance(selector, str):
-            selector_fn = lambda this: this[selector]
+            selector_fn = lambda this: this.get(selector, default_value)
         elif isiterable(selector):
             selector_fn = lambda this: { key : this[key] for key in selector }
         else:

--- a/st3/sublime_lib/fancy_settings.py
+++ b/st3/sublime_lib/fancy_settings.py
@@ -14,17 +14,26 @@ class FancySettings():
         self.settings = settings
         self.defaults = defaults
 
-    def get(self, key, default=None):
-        return self.settings.get(key, self.defaults.get(key, default))
+    def __getitem__(self, key):
+        if key in self or key in self.defaults:
+            return self.get(key)
+        else:
+            raise KeyError(key)
 
-    def set(self, key, value):
+    def __setitem__(self, key, value):
         self.settings.set(key, value)
 
-    def erase(self, key):
-        self.settings.erase(key)
+    def __delitem__(self, key):
+        if self.has(name):
+            self.settings.erase(name)
+        else:
+            raise KeyError(name)
 
-    def has(self, key):
-        return self.settings.has(key)
+    def __contains__(self, item):
+        return self.settings.has(item)
+
+    def get(self, key, default=None):
+        return self.settings.get(key, self.defaults.get(key, default))
 
     def pop(self, key, default=NOT_GIVEN):
         if key in self:
@@ -42,24 +51,6 @@ class FancySettings():
         else:
             self.set(key, default)
             return default
-
-    def __getitem__(self, key):
-        if key in self or key in self.defaults:
-            return self.get(key)
-        else:
-            raise KeyError(key)
-
-    def __setitem__(self, key, value):
-        self.set(key, value)
-
-    def __delitem__(self, key):
-        if self.has(name):
-            self.erase(name)
-        else:
-            raise KeyError(name)
-
-    def __contains__(self, item):
-        return self.has(item)
 
     def update(*pairs, **kwargs):
         for key, value in pairs:

--- a/tests/test_fancy_settings.py
+++ b/tests/test_fancy_settings.py
@@ -1,0 +1,22 @@
+import sublime
+from sublime_lib import FancySettings
+
+from unittest import TestCase
+
+class TestFancySettings(TestCase):
+
+    def setUp(self):
+        self.view = sublime.active_window().new_file()
+        self.settings = self.view.settings()
+        self.settings.set("example_setting", "Hello, World!")
+
+    def tearDown(self):
+        if self.view:
+            self.view.set_scratch(True)
+            self.view.window().focus_view(self.view)
+            self.view.window().run_command("close_file")
+
+    def test_get(self):
+        fancy = FancySettings(self.settings)
+
+        self.assertEqual(fancy['example_setting'], "Hello, World!")

--- a/tests/test_fancy_settings.py
+++ b/tests/test_fancy_settings.py
@@ -50,6 +50,54 @@ class TestFancySettings(TestCase):
         self.assertEqual(self.settings.get('example_setting'), "Hello, World!")
 
 
+    def test_delete(self):
+        self.fancy["example_setting"] = "Hello, World!"
+        del self.fancy["example_setting"]
+        self.assertNotIn("example_setting", self.fancy)
+
+    def test_delete_missing_error(self):
+        self.fancy["example_setting"] = "Hello, World!"
+        del self.fancy["example_setting"]
+        self.assertRaises(KeyError, self.fancy.__delitem__, "example_setting")
+
+
+    def test_contains(self):
+        self.assertNotIn("example_setting", self.fancy)
+        self.fancy["example_setting"] = "Hello, World!"
+        self.assertIn("example_setting", self.fancy)
+
+
+    def test_pop(self):
+        self.fancy["example_setting"] = "Hello, World!"
+        result = self.fancy.pop("example_setting")
+
+        self.assertEqual(result, "Hello, World!")
+        self.assertNotIn("example_setting", self.fancy)
+
+        default = self.fancy.pop("example_setting", 42)
+        self.assertEqual(default, 42)
+
+        self.assertRaises(KeyError, self.fancy.pop, "example_setting")
+
+
+    def test_setdefault(self):
+        result = self.fancy.setdefault("example_setting", "Hello, World!")
+
+        self.assertEqual(result, "Hello, World!")
+        self.assertEqual(self.fancy["example_setting"], "Hello, World!")
+
+        result = self.fancy.setdefault("example_setting", 42)
+
+        self.assertEqual(result, "Hello, World!")
+        self.assertEqual(self.fancy["example_setting"], "Hello, World!")
+
+    def test_setdefault_none(self):
+        result = self.fancy.setdefault("example_setting")
+
+        self.assertEqual(result, None)
+        self.assertEqual(self.fancy["example_setting"], None)
+
+
     def test_update(self):
         self.fancy["foo"] = "Hello, World!"
 

--- a/tests/test_fancy_settings.py
+++ b/tests/test_fancy_settings.py
@@ -8,7 +8,7 @@ class TestFancySettings(TestCase):
     def setUp(self):
         self.view = sublime.active_window().new_file()
         self.settings = self.view.settings()
-        self.settings.set("example_setting", "Hello, World!")
+        self.fancy = FancySettings(self.settings)
 
     def tearDown(self):
         if self.view:
@@ -16,7 +16,35 @@ class TestFancySettings(TestCase):
             self.view.window().focus_view(self.view)
             self.view.window().run_command("close_file")
 
-    def test_get(self):
-        fancy = FancySettings(self.settings)
 
-        self.assertEqual(fancy['example_setting'], "Hello, World!")
+    def test_item(self):
+        self.settings.set("example_setting", "Hello, World!")
+
+        self.assertEqual(self.fancy['example_setting'], "Hello, World!")
+
+    def test_item_missing_error(self):
+        self.settings.erase("example_setting")
+
+        self.assertRaises(KeyError, lambda k: self.fancy[k], "example_setting")
+
+
+    def test_get(self):
+        self.settings.set("example_setting", "Hello, World!")
+
+        self.assertEqual(self.fancy.get('example_setting'), "Hello, World!")
+
+    def test_get_missing_none(self):
+        self.settings.erase("example_setting")
+
+        self.assertIsNone(self.fancy.get("example_setting"))
+
+    def test_get_missing_default(self):
+        self.settings.erase("example_setting")
+
+        self.assertEqual(self.fancy.get("example_setting", "default"), "default")
+
+
+    def test_set(self):
+        self.fancy["example_setting"] = "Hello, World!"
+
+        self.assertEqual(self.settings.get('example_setting'), "Hello, World!")

--- a/tests/test_fancy_settings.py
+++ b/tests/test_fancy_settings.py
@@ -48,3 +48,16 @@ class TestFancySettings(TestCase):
         self.fancy["example_setting"] = "Hello, World!"
 
         self.assertEqual(self.settings.get('example_setting'), "Hello, World!")
+
+
+    def test_update(self):
+        self.fancy["foo"] = "Hello, World!"
+
+        self.fancy.update({'foo': 1, 'bar': 2}, xyzzy = 3)
+        self.fancy.update([('bar', 20), ('baz', 30)], yzzyx = 4)
+
+        self.assertEqual(self.fancy['foo'], 1)
+        self.assertEqual(self.fancy['bar'], 20)
+        self.assertEqual(self.fancy['baz'], 30)
+        self.assertEqual(self.fancy['xyzzy'], 3)
+        self.assertEqual(self.fancy['yzzyx'], 4)


### PR DESCRIPTION
For #2.

The name could be changed. I'd be a bit leery of simply calling it “Settings”.

The `subscribe` method takes a “selector”, which maps the current state of a `FancySettings` to some value. (If `selector` is a string, it is interpreted as the name of a top-level setting.) When the `Settings` changes, if and only if the selected value changes, the given callback will be invoked with the new and old value as arguments. This is what I'd need for JS Custom, and I think it should handle most use cases.

Default values are not handled in this PR, though they should be easily compatible with this implementation.

The built-in `Settings` class supplies `None` for a nonexistent key instead of raising a `KeyError`. Should we follow suit or be stricter? Myself, I'd generally lean toward stricter, because the user can always provide a default value in `get`. This PR is loose, like the builtin.

It would be nice to be able to enumerate settings, but I don't think the Sublime API allows for this.