### PR TITLE
Added ViewTestCase -- a subclass of unittest.TestCase.

### DIFF
--- a/st3/sublime_lib/testing.py
+++ b/st3/sublime_lib/testing.py
@@ -1,0 +1,19 @@
+import sublime
+
+from unittest import TestCase
+
+class ViewTestCase(TestCase):
+    def setUp(self):
+        self.view = sublime.active_window().new_file()
+
+    def tearDown(self):
+        if self.view:
+            self.view.set_scratch(True)
+            self.view.window().focus_view(self.view)
+            self.view.window().run_command("close_file")
+
+    def assertContents(self, text):
+        self.assertEqual(
+            self.view.substr(sublime.Region(0, self.view.size())),
+            text
+        )

--- a/tests/test_fancy_settings.py
+++ b/tests/test_fancy_settings.py
@@ -1,20 +1,14 @@
 import sublime
 from sublime_lib import FancySettings
 
-from unittest import TestCase
+from sublime_lib.testing import ViewTestCase
 
-class TestFancySettings(TestCase):
+class TestFancySettings(ViewTestCase):
 
     def setUp(self):
-        self.view = sublime.active_window().new_file()
+        super().setUp()
         self.settings = self.view.settings()
         self.fancy = FancySettings(self.settings)
-
-    def tearDown(self):
-        if self.view:
-            self.view.set_scratch(True)
-            self.view.window().focus_view(self.view)
-            self.view.window().run_command("close_file")
 
 
     def test_item(self):

--- a/tests/test_output_panel.py
+++ b/tests/test_output_panel.py
@@ -1,25 +1,19 @@
 import sublime
 from sublime_lib import OutputPanel
 
-from unittest import TestCase
+from sublime_lib.testing import ViewTestCase
 
-class TestOutputPanel(TestCase):
+class TestOutputPanel(ViewTestCase):
 
     def setUp(self):
         self.window = sublime.active_window()
-        self.panel_name = "test_panel"
-        self.panel = OutputPanel(self.window, self.panel_name)
+        self.panel = OutputPanel(self.window, "test_panel")
+        self.view = self.panel.view
         self.panel.show()
 
     def tearDown(self):
         self.panel.destroy()
 
-    def assertContents(self, text):
-        view = self.panel.view
-        self.assertEqual(
-            view.substr(sublime.Region(0, view.size())),
-            text
-        )
 
     def test_stream_operations(self):
         self.panel.write("Hello, ")

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -1,25 +1,13 @@
 import sublime
 from sublime_lib import ViewStream
 
-from unittest import TestCase
+from sublime_lib.testing import ViewTestCase
 
-class TestViewStream(TestCase):
+class TestViewStream(ViewTestCase):
 
     def setUp(self):
-        self.view = sublime.active_window().new_file()
+        super().setUp()
         self.stream = ViewStream(self.view)
-
-    def tearDown(self):
-        if self.view:
-            self.view.set_scratch(True)
-            self.view.window().focus_view(self.view)
-            self.view.window().run_command("close_file")
-
-    def assertContents(self, text):
-        self.assertEqual(
-            self.view.substr(sublime.Region(0, self.view.size())),
-            text
-        )
 
     def test_stream_operations(self):
         self.stream.write("Hello, ")


### PR DESCRIPTION
`ViewTestCase` has predefined `setUp` and `tearDown` methods and a new `assertContents` method. This should factor out some of the boilerplate from our tests, and I think that this would be a widely useful feature to expose, because most unit tests for Sublime packages would probably involve creating a view, doing something to it, checking the results, and then tearing it down.

The name `assertContents` isn't quite in the style of the other `TestCase` methods. More correct would be `assertViewContentsEqual`, which seems a bit verbose. But maybe that would work best, along with an `assertViewContentsNotEqual`.