### PR TITLE
ViewStream implements TextIOBase

### DIFF
--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -1,8 +1,9 @@
 from sublime import Region
-from io import SEEK_SET, SEEK_CUR, SEEK_END, TextIOBase, UnsupportedOperation
+from io import SEEK_SET, SEEK_CUR, SEEK_END, TextIOBase
 
-"""A writable text stream encapsulating a `sublime.View` object."""
+
 class ViewStream(TextIOBase):
+    """A writable text stream encapsulating a `sublime.View` object."""
 
     def __init__(self, view):
         self.view = view
@@ -87,7 +88,6 @@ class ViewStream(TextIOBase):
         self._check_is_valid()
         self._check_selection()
         return self.view.sel()[0].b
-
 
     """Erase all text in the view.
 

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -3,7 +3,15 @@ from io import SEEK_SET, SEEK_CUR, SEEK_END, TextIOBase
 
 
 class ViewStream(TextIOBase):
-    """A writable text stream encapsulating a `sublime.View` object."""
+    """A TextIO encapsulating a `sublime.View` object.
+
+    All public methods (except flush) require that the underlying View object
+    be valid (using View.is_valid). Otherwise, ValueError will be raised.
+
+    The `read`, `readline`, `write`, and `tell` methods require that the
+    underlying View have exactly one selection, and that the selection is
+    empty (i.e. a simple cursor). Otherwise, ValueError will be raised.
+    """
 
     def __init__(self, view):
         self.view = view
@@ -20,14 +28,45 @@ class ViewStream(TextIOBase):
         if not self.view.is_valid():
             raise ValueError("The underlying view is invalid.")
 
-    """Insert the string <var>s</var> into the view and return the number of
-    characters inserted. The string will be inserted immediately before the
-    cursor.
+    def read(self, size):
+        """Read and return at most <var>size</var> characters from the stream as a
+        single `str`. If <var>size</var> is negative or None, reads until EOF.
+        """
 
-    Precondition: The view is valid. (ValueError)
-    Precondition: The view has exactly one selection. (ValueError)
-    """
+        self._check_is_valid()
+        self._check_selection()
+
+        begin = self._tell()
+        end = self.view.size()
+
+        return self._read(begin, end, size)
+
+    def readline(self, size=-1):
+        """Read until newline or EOF and return a single `str`. If the stream is
+        already at EOF, an empty string is returned.
+        """
+
+        self._check_is_valid()
+        self._check_selection()
+
+        begin = self._tell()
+        end = self.view.full_line(begin).end()
+
+        return self._read(begin, end, size)
+
+    def _read(self, begin, end, size):
+        if size is not None and size >= 0:
+            end = min(end, begin + size)
+
+        self._seek(end)
+        return self.view.substr(Region(begin, end))
+
     def write(self, s):
+        """Insert the string <var>s</var> into the view and return the number of
+        characters inserted. The string will be inserted immediately before the
+        cursor.
+        """
+
         self._check_is_valid()
         self._check_selection()
         self.view.run_command('insert', {'characters': s})
@@ -36,64 +75,61 @@ class ViewStream(TextIOBase):
     def print(self, *objects, **kwargs):
         print(*objects, file=self, **kwargs)
 
-    """Do nothing. (The stream is unbuffered.)"""
     def flush(self):
+        """Do nothing. (The stream is not buffered.)"""
         pass
 
-    """Move the cursor in the view to the given index. If `whence` is provided,
-    the behavior is the same as for TextIOBase. If the view had multiple
-    selections, none will be preserved.
+    def seek(self, offset, whence=SEEK_SET):
+        """Move the cursor in the view to the given offset. If `whence` is
+        provided, the behavior is the same as for TextIOBase. If the view had
+        multiple selections, none will be preserved.
+        """
 
-    Precondition: The view is valid. (ValueError)
-    """
-    def seek(self, index, whence=SEEK_SET):
         self._check_is_valid()
+
         if whence == SEEK_SET:
-            self._seek(index)
+            return self._seek(offset)
         elif whence == SEEK_CUR:
-            if index != 0:
-                raise TypeError('Argument "index" must be zero when "whence" '
+            if offset != 0:
+                raise TypeError('Argument "offset" must be zero when "whence" '
                                 'is io.SEEK_CUR.')
-            pass  # Do nothing.
+            # Don't move.
+            return self._tell()
         elif whence == SEEK_END:
-            if index != 0:
-                raise TypeError('Argument "index" must be zero when "whence" '
+            if offset != 0:
+                raise TypeError('Argument "offset" must be zero when "whence" '
                                 'is io.SEEK_END.')
-            self._seek(self.view.size())
+            return self._seek(self.view.size())
         else:
             raise TypeError('Invalid value for argument "whence".')
 
-    def _seek(self, index):
+    def _seek(self, offset):
         selection = self.view.sel()
         selection.clear()
-        selection.add(Region(index))
+        selection.add(Region(offset))
+        return offset
 
-    """Move the cursor in the view to before the first character.
-
-    Precondition: The view is valid. (ValueError)
-    """
     def seek_start(self):
+        """Move the cursor in the view to before the first character."""
         self._check_is_valid()
         self._seek(0)
 
-    """Move the cursor in the view to after the last character.
-
-    Precondition: The view is valid. (ValueError)
-    """
     def seek_end(self):
+        """Move the cursor in the view to after the last character."""
         self._check_is_valid()
         self._seek(self.view.size())
 
     def tell(self):
+        """Return the character offset of the cursor."""
         self._check_is_valid()
         self._check_selection()
+        return self._tell()
+
+    def _tell(self):
         return self.view.sel()[0].b
 
-    """Erase all text in the view.
-
-    Precondition: The view is valid. (ValueError)
-    """
     def clear(self):
+        """Erase all text in the view."""
         self._check_is_valid()
         self.view.run_command('select_all')
         self.view.run_command('left_delete')

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -22,8 +22,8 @@ class ViewStream(TextIOBase):
     characters inserted. The string will be inserted immediately before the
     cursor.
 
-    @precondition: The view is valid. (ValueError)
-    @precondition: The view has exactly one selection. (ValueError)
+    Precondition: The view is valid. (ValueError)
+    Precondition: The view has exactly one selection. (ValueError)
     """
     def write(self, s):
         self._check_is_valid()
@@ -34,7 +34,7 @@ class ViewStream(TextIOBase):
     def print(self, *objects, **kwargs):
         print(*objects, file=self, **kwargs)
 
-    """Do nothing."""
+    """Do nothing. (The stream is unbuffered.)"""
     def flush(self):
         pass
 
@@ -42,7 +42,7 @@ class ViewStream(TextIOBase):
     the behavior is the same as for TextIOBase. If the view had multiple
     selections, none will be preserved.
 
-    @precondition: The view is valid. (ValueError)
+    Precondition: The view is valid. (ValueError)
     """
     def seek(self, index, whence=SEEK_SET):
         self._check_is_valid()
@@ -64,7 +64,7 @@ class ViewStream(TextIOBase):
 
     """Move the cursor in the view to before the first character.
 
-    @precondition: The view is valid. (ValueError)
+    Precondition: The view is valid. (ValueError)
     """
     def seek_start(self):
         self._check_is_valid()
@@ -72,7 +72,7 @@ class ViewStream(TextIOBase):
 
     """Move the cursor in the view to after the last character.
 
-    @precondition: The view is valid. (ValueError)
+    Precondition: The view is valid. (ValueError)
     """
     def seek_end(self):
         self._check_is_valid()
@@ -86,7 +86,7 @@ class ViewStream(TextIOBase):
 
     """Erase all text in the view.
 
-    @precondition: The view is valid. (ValueError)
+    Precondition: The view is valid. (ValueError)
     """
     def clear(self):
         self._check_is_valid()

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -1,20 +1,30 @@
 from sublime import Region
-from io import SEEK_SET, SEEK_CUR, SEEK_END
+from io import SEEK_SET, SEEK_CUR, SEEK_END, TextIOBase, UnsupportedOperation
 
-class ViewStream():
+"""A writable text stream encapsulating a `sublime.View` object."""
+class ViewStream(TextIOBase):
     def __init__(self, view):
         self.view = view
 
     def _check_selection(self):
         if len(self.view.sel()) == 0:
             raise ValueError("The underlying view has no selection.")
-        if len(self.view.sel()) > 1:
+        elif len(self.view.sel()) > 1:
             raise ValueError("The underlying view has multiple selections.")
+        elif not self.view.sel()[0].empty():
+            raise ValueError("The underlying view's selection is not empty.")
 
     def _check_is_valid(self):
         if not self.view.is_valid():
             raise ValueError("The underlying view is invalid.")
 
+    """Insert the string <var>s</var> into the view and return the number of
+    characters inserted. The string will be inserted immediately before the
+    cursor.
+
+    @precondition: The view is valid. (ValueError)
+    @precondition: The view has exactly one selection. (ValueError)
+    """
     def write(self, s):
         self._check_is_valid()
         self._check_selection()
@@ -24,30 +34,60 @@ class ViewStream():
     def print(self, *objects, **kwargs):
         print(*objects, file=self, **kwargs)
 
+    """Do nothing."""
     def flush(self):
         pass
 
+    """Move the cursor in the view to the given index. If `whence` is provided,
+    the behavior is the same as for TextIOBase. If the view had multiple
+    selections, none will be preserved.
+
+    @precondition: The view is valid. (ValueError)
+    """
     def seek(self, index, whence=SEEK_SET):
         self._check_is_valid()
         if whence == SEEK_SET:
-            selection = self.view.sel()
-            selection.clear()
-            selection.add(Region(index))
+            self._seek(index)
         elif whence == SEEK_CUR:
             if index != 0: raise TypeError('Argument "index" must be zero when "whence" is io.SEEK_CUR.')
             pass # Do nothing.
         elif whence == SEEK_END:
             if index != 0: raise TypeError('Argument "index" must be zero when "whence" is io.SEEK_END.')
-            self.seek(self.view.size())
+            self._seek(self.view.size())
         else:
             raise TypeError('Invalid value for argument "whence".')
 
+    def _seek(self, index):
+        selection = self.view.sel()
+        selection.clear()
+        selection.add(Region(index))
+
+    """Move the cursor in the view to before the first character.
+
+    @precondition: The view is valid. (ValueError)
+    """
     def seek_start(self):
-        self.seek(0)
+        self._check_is_valid()
+        self._seek(0)
 
+    """Move the cursor in the view to after the last character.
+
+    @precondition: The view is valid. (ValueError)
+    """
     def seek_end(self):
-        self.seek(self.view.size())
+        self._check_is_valid()
+        self._seek(self.view.size())
 
+    def tell(self):
+        self._check_is_valid()
+        self._check_selection()
+        return self.view.sel()[0].b
+
+
+    """Erase all text in the view.
+
+    @precondition: The view is valid. (ValueError)
+    """
     def clear(self):
         self._check_is_valid()
         self.view.run_command('select_all')

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -2,6 +2,7 @@ import sublime
 from sublime_lib import ViewStream
 
 from unittest import TestCase
+from io import UnsupportedOperation
 
 class TestViewStream(TestCase):
 
@@ -24,11 +25,14 @@ class TestViewStream(TestCase):
     def test_stream_operations(self):
         self.stream.write("Hello, ")
         self.stream.print("World!")
+        self.assertEqual(self.stream.tell(), 14)
         
         self.stream.seek_start()
+        self.assertEqual(self.stream.tell(), 0)
         self.stream.print("Top")
 
         self.stream.seek_end()
+        self.assertEqual(self.stream.tell(), 18)
         self.stream.print("Bottom")
 
         self.stream.seek(4)
@@ -40,3 +44,8 @@ class TestViewStream(TestCase):
         self.stream.write("Some text")
         self.stream.clear()
         self.assertContents("")
+
+    def test_unsupported(self):
+        self.assertRaises(UnsupportedOperation, self.stream.detach)
+        self.assertRaises(UnsupportedOperation, self.stream.read, 1)
+        self.assertRaises(UnsupportedOperation, self.stream.readline)

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -46,7 +46,55 @@ class TestViewStream(TestCase):
         self.stream.clear()
         self.assertContents("")
 
+    def test_read(self):
+        self.stream.write("Hello, World!\nGoodbye, World!")
+
+        self.stream.seek(7)
+        text = self.stream.read(5)
+        self.assertEqual(text, "World")
+        self.assertEqual(self.stream.tell(), 12)
+
+        text = self.stream.read(3)
+        self.assertEqual(text, "!\nG")
+        self.assertEqual(self.stream.tell(), 15)
+
+        text = self.stream.read(1000)
+        self.assertEqual(text, "oodbye, World!")
+        self.assertEqual(self.stream.tell(), self.stream.view.size())
+
+        self.stream.seek(7)
+        text = self.stream.read(None)
+        self.assertEqual(text, "World!\nGoodbye, World!")
+
+        self.stream.seek(7)
+        text = self.stream.read(-1)
+        self.assertEqual(text, "World!\nGoodbye, World!")
+
+    def test_readline(self):
+        self.stream.write("Hello, World!\nGoodbye, World!")
+
+        self.stream.seek(7)
+        text = self.stream.readline()
+        self.assertEqual(text, "World!\n")
+        self.assertEqual(self.stream.tell(), 14)
+
+        text = self.stream.readline()
+        self.assertEqual(text, "Goodbye, World!")
+
+        self.stream.seek(7)
+        text = self.stream.readline(1000)
+        self.assertEqual(text, "World!\n")
+        self.assertEqual(self.stream.tell(), 14)
+
+        self.stream.seek(7)
+        text = self.stream.readline(-1)
+        self.assertEqual(text, "World!\n")
+        self.assertEqual(self.stream.tell(), 14)
+
+        self.stream.seek(7)
+        text = self.stream.readline(5)
+        self.assertEqual(text, "World")
+        self.assertEqual(self.stream.tell(), 12)
+
     def test_unsupported(self):
         self.assertRaises(UnsupportedOperation, self.stream.detach)
-        self.assertRaises(UnsupportedOperation, self.stream.read, 1)
-        self.assertRaises(UnsupportedOperation, self.stream.readline)


### PR DESCRIPTION
- ViewStream now extends [io.TextIOBase](https://docs.python.org/3/library/io.html#io.TextIOBase).
- `_check_selection` will raise if the selection is nonempty, because this could produce surprising behavior with `write` and `tell`.
- `seek` is refactored to avoid redundant checks.
- New `tell` method gives the position of the cursor.
- `read`, `readline`, and `detach` exist and raise `io.UnsupportedOperation`. We could implement `read` and `readline` if we want to.
- Documentation and tests.