### PR TITLE
Added settings argument to OutputPanel.

### DIFF
--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -2,11 +2,16 @@ from .view_stream import ViewStream
 
 
 class OutputPanel(ViewStream):
-    def __init__(self, window, name):
+    def __init__(self, window, name, *, settings=None):
         super().__init__(window.get_output_panel(name))
 
         self.window = window
         self.name = name
+
+        if settings:
+            view_settings = self.view.settings()
+            for key, value in settings.items():
+                view_settings.set(key, value)
 
     @property
     def full_name(self):

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -2,16 +2,22 @@ from .view_stream import ViewStream
 
 
 class OutputPanel(ViewStream):
-    def __init__(self, window, name, *, settings=None):
+    def __init__(self, window, name, *,
+        settings=None,
+        read_only=None
+    ):
         super().__init__(window.get_output_panel(name))
 
         self.window = window
         self.name = name
 
-        if settings:
+        if settings is not None:
             view_settings = self.view.settings()
             for key, value in settings.items():
                 view_settings.set(key, value)
+
+        if read_only is not None:
+            view.set_read_only(read_only)
 
     @property
     def full_name(self):

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -2,7 +2,8 @@ from .view_stream import ViewStream
 
 
 class OutputPanel(ViewStream):
-    def __init__(self, window, name, *,
+    def __init__(
+        self, window, name, *,
         settings=None,
         read_only=None
     ):
@@ -17,7 +18,7 @@ class OutputPanel(ViewStream):
                 view_settings.set(key, value)
 
         if read_only is not None:
-            view.set_read_only(read_only)
+            self.view.set_read_only(read_only)
 
     @property
     def full_name(self):

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -4,10 +4,14 @@ from .view_stream import ViewStream
 class OutputPanel(ViewStream):
     def __init__(
         self, window, name, *,
+        force_writes=False,
         settings=None,
         read_only=None
     ):
-        super().__init__(window.get_output_panel(name))
+        super().__init__(
+            window.get_output_panel(name),
+            force_writes=force_writes
+        )
 
         self.window = window
         self.name = name

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -16,8 +16,13 @@ class ViewStream():
         if not self.view.is_valid():
             raise ValueError("The underlying view is invalid.")
 
+    def _check_writable(self):
+        if self.view.is_read_only():
+            raise ValueError("The underlying view is read-only.")
+
     def write(self, s):
         self._check_is_valid()
+        self._check_writable()
         self._check_selection()
         self.view.run_command('insert', {'characters': s})
         return len(s)

--- a/tests/test_output_panel.py
+++ b/tests/test_output_panel.py
@@ -61,3 +61,11 @@ class TestOutputPanel(TestCase):
     def test_destroy(self):
         self.panel.destroy()
         self.assertIsNone(self.window.find_output_panel(self.panel.name))
+
+    def test_settings(self):
+        self.panel = OutputPanel(self.window, self.panel_name, settings={
+            "test_setting": "Hello, World!"
+        })
+
+        view_settings = self.panel.view.settings()
+        self.assertEqual(view_settings.get("test_setting"), "Hello, World!")

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -96,5 +96,13 @@ class TestViewStream(TestCase):
         self.assertEqual(text, "World")
         self.assertEqual(self.stream.tell(), 12)
 
+    def test_write_only(self):
+        self.stream.view.set_read_only(True)
+
+        self.assertRaises(ValueError, self.stream.write, 'foo')
+
+        self.stream.force_writes = True
+        self.assertEqual(self.stream.write('foo'), 3)
+
     def test_unsupported(self):
         self.assertRaises(UnsupportedOperation, self.stream.detach)

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -100,9 +100,13 @@ class TestViewStream(TestCase):
         self.stream.view.set_read_only(True)
 
         self.assertRaises(ValueError, self.stream.write, 'foo')
+        self.assertRaises(ValueError, self.stream.clear)
 
         self.stream.force_writes = True
         self.assertEqual(self.stream.write('foo'), 3)
+
+        self.stream.clear()
+        self.assertEqual(self.stream.view.size(), 0)
 
     def test_unsupported(self):
         self.assertRaises(UnsupportedOperation, self.stream.detach)


### PR DESCRIPTION
You can pass a dictionary of settings to `__init__` to set them in the panel's view.

In addition to handling syntaxes and such, I'm hoping that this will suffice in place of more specific methods to handle error regexps.