### PR TITLE
Added syntax utilities.

### DIFF
--- a/st3/sublime_lib/syntax.py
+++ b/st3/sublime_lib/syntax.py
@@ -1,0 +1,41 @@
+import sublime
+
+import re
+
+__all__ = ['list_syntaxes', 'get_syntax_for_scope']
+
+class SyntaxInfo():
+    __slots__ = [ 'path', 'name', 'scope', 'hidden' ]
+    
+    def __init__(self, path, name=None, scope=None, hidden=False):
+        self.path = path
+        self.name = name
+        self.scope = scope
+        self.hidden = hidden
+
+def get_syntax_metadata(path, text):
+    ret = {}
+
+    keys = { 'name', 'scope', 'hidden' }
+
+    for line in text.splitlines():
+        m = re.match(r'^(\w+):\s*(.*?)\s*$', line)
+        if not m: continue
+        key, value = m.groups()
+        if key in keys:
+            ret[key] = value
+
+    return SyntaxInfo(path=path, **ret)
+
+def list_syntaxes():
+    return [
+        get_syntax_metadata(path, sublime.load_resource(path))
+        for path in sublime.find_resources('*.sublime-syntax')
+    ]
+
+def get_syntax_for_scope(scope):
+    return next((
+        syntax.path
+        for syntax in list_syntaxes()
+        if syntax.scope == scope
+    ), None)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -1,0 +1,20 @@
+import sublime
+
+from sublime_lib.syntax import list_syntaxes
+from sublime_lib.syntax import get_syntax_for_scope
+
+from unittest import TestCase
+from io import UnsupportedOperation
+
+
+class TestSyntax(TestCase):
+
+    def test_list_syntaxes(self):
+        syntaxes = list_syntaxes()
+        self.assertTrue(syntaxes)
+
+    def test_get_syntax(self):
+        self.assertEqual(
+            get_syntax_for_scope('source.python'),
+            'Packages/Python/Python.sublime-syntax'
+        )


### PR DESCRIPTION
For #16. We expose `list_syntaxes` and `get_syntax_for_scope`.

This uses a quick-and-dirty regexp parser. It should work in practice for virtually all syntax definitions. It's surprisingly fast even without caching. Caching might still be a good idea, but it would be fairly complicated to implement.

`get_syntax_for_scope` doesn't prioritize properly.