### PR TITLE
Use decorators to ensure valid ViewStream state

### DIFF
--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -1,4 +1,5 @@
 from .view_stream import ViewStream
+from .view_stream import _guard, _guard_validity
 
 
 class OutputPanel(ViewStream):
@@ -28,12 +29,12 @@ class OutputPanel(ViewStream):
     def full_name(self):
         return "output.%s" % self.name
 
+    @_guard(_guard_validity)
     def show(self):
-        self._check_is_valid()
         self.window.run_command("show_panel", {"panel": self.full_name})
 
+    @_guard(_guard_validity)
     def hide(self):
-        self._check_is_valid()
         self.window.run_command("hide_panel", {"panel": self.full_name})
 
     def destroy(self):

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -1,5 +1,4 @@
 from .view_stream import ViewStream
-from .view_stream import _guard, _guard_validity
 
 
 class OutputPanel(ViewStream):
@@ -29,11 +28,11 @@ class OutputPanel(ViewStream):
     def full_name(self):
         return "output.%s" % self.name
 
-    @_guard(_guard_validity)
+    @ViewStream.guard_validity
     def show(self):
         self.window.run_command("show_panel", {"panel": self.full_name})
 
-    @_guard(_guard_validity)
+    @ViewStream.guard_validity
     def hide(self):
         self.window.run_command("hide_panel", {"panel": self.full_name})
 

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -1,47 +1,19 @@
 from sublime import Region
 
-import contextlib
+from contextlib import contextmanager
 from functools import wraps
 from io import SEEK_SET, SEEK_CUR, SEEK_END, TextIOBase
 
 
-@contextlib.contextmanager
-def _guard_read_only(self):
-    if self.view.is_read_only():
-        if self.force_writes:
-            self.view.set_read_only(False)
-            yield
-            self.view.set_read_only(True)
-        else:
-            raise ValueError("The underlying view is read-only.")
-    else:
-        yield
-
-
-def _guard_validity(self):
-    if not self.view.is_valid():
-        raise ValueError("The underlying view is invalid.")
-
-
-def _guard_selection(self, *args, **kwargs):
-    if len(self.view.sel()) == 0:
-        raise ValueError("The underlying view has no selection.")
-    elif len(self.view.sel()) > 1:
-        raise ValueError("The underlying view has multiple selections.")
-    elif not self.view.sel()[0].empty():
-        raise ValueError("The underlying view's selection is not empty.")
-
-
-def _guard(*guards):
+def define_guard(guard_fn):
     def decorator(wrapped):
         @wraps(wrapped)
         def wrapper_guards(self, *args, **kwargs):
-            with contextlib.ExitStack() as stack:
-                for guard in guards:
-                    ret_val = guard(self)
-                    if hasattr(ret_val, '__enter__'):
-                        stack.enter_context(ret_val)
-
+            ret_val = guard_fn(self)
+            if hasattr(ret_val, '__enter__'):
+                with ret_val:
+                    return wrapped(self, *args, **kwargs)
+            else:
                 return wrapped(self, *args, **kwargs)
 
         return wrapper_guards
@@ -60,11 +32,39 @@ class ViewStream(TextIOBase):
     empty (i.e. a simple cursor). Otherwise, ValueError will be raised.
     """
 
+    @define_guard
+    @contextmanager
+    def guard_read_only(self):
+        if self.view.is_read_only():
+            if self.force_writes:
+                self.view.set_read_only(False)
+                yield
+                self.view.set_read_only(True)
+            else:
+                raise ValueError("The underlying view is read-only.")
+        else:
+            yield
+
+    @define_guard
+    def guard_validity(self):
+        if not self.view.is_valid():
+            raise ValueError("The underlying view is invalid.")
+
+    @define_guard
+    def guard_selection(self):
+        if len(self.view.sel()) == 0:
+            raise ValueError("The underlying view has no selection.")
+        elif len(self.view.sel()) > 1:
+            raise ValueError("The underlying view has multiple selections.")
+        elif not self.view.sel()[0].empty():
+            raise ValueError("The underlying view's selection is not empty.")
+
     def __init__(self, view, *, force_writes=False):
         self.view = view
         self.force_writes = force_writes
 
-    @_guard(_guard_validity, _guard_selection)
+    @guard_validity
+    @guard_selection
     def read(self, size):
         """Read and return at most <var>size</var> characters from the stream as a
         single `str`. If <var>size</var> is negative or None, reads until EOF.
@@ -74,7 +74,8 @@ class ViewStream(TextIOBase):
 
         return self._read(begin, end, size)
 
-    @_guard(_guard_validity, _guard_selection)
+    @guard_validity
+    @guard_selection
     def readline(self, size=-1):
         """Read until newline or EOF and return a single `str`. If the stream is
         already at EOF, an empty string is returned.
@@ -91,7 +92,9 @@ class ViewStream(TextIOBase):
         self._seek(end)
         return self.view.substr(Region(begin, end))
 
-    @_guard(_guard_validity, _guard_selection, _guard_read_only)
+    @guard_validity
+    @guard_selection
+    @guard_read_only
     def write(self, s):
         """Insert the string <var>s</var> into the view and return the number of
         characters inserted. The string will be inserted immediately before the
@@ -107,7 +110,7 @@ class ViewStream(TextIOBase):
         """Do nothing. (The stream is not buffered.)"""
         pass
 
-    @_guard(_guard_validity)
+    @guard_validity
     def seek(self, offset, whence=SEEK_SET):
         """Move the cursor in the view to the given offset. If `whence` is
         provided, the behavior is the same as for TextIOBase. If the view had
@@ -135,17 +138,18 @@ class ViewStream(TextIOBase):
         selection.add(Region(offset))
         return offset
 
-    @_guard(_guard_validity)
+    @guard_validity
     def seek_start(self):
         """Move the cursor in the view to before the first character."""
         self._seek(0)
 
-    @_guard(_guard_validity)
+    @guard_validity
     def seek_end(self):
         """Move the cursor in the view to after the last character."""
         self._seek(self.view.size())
 
-    @_guard(_guard_validity, _guard_selection)
+    @guard_validity
+    @guard_selection
     def tell(self):
         """Return the character offset of the cursor."""
         return self._tell()
@@ -153,7 +157,9 @@ class ViewStream(TextIOBase):
     def _tell(self):
         return self.view.sel()[0].b
 
-    @_guard(_guard_validity, _guard_read_only)
+    @guard_validity
+    @guard_selection
+    @guard_read_only
     def clear(self):
         """Erase all text in the view."""
         self.view.run_command('select_all')

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -115,18 +115,28 @@ class TestViewStream(TestCase):
         sel = self.view.sel()
         sel.clear()
         self.assertRaises(ValueError, self.stream.write, "\n")
+
         sel.add(0)
         self.stream.write("\n")
+
         sel.add(0)
         self.assertRaises(ValueError, self.stream.write, "\n")
+
         sel.clear()
         sel.add(sublime.Region(0, 1))
         self.assertRaises(ValueError, self.stream.write, "\n")
 
-    # TODO how to invalidate a view?
-    # def test_validity_guard(self):
-    #     self.view.set_scratch(True)
-    #     self.view.window().focus_view(self.view)
-    #     self.view.window().run_command("close_file")
-    #     self.view = None
-    #     self.assertRaises(ValueError, self.stream.write, "\n")
+    def test_validity_guard(self):
+        self.view.set_scratch(True)
+        self.view.window().focus_view(self.view)
+        self.view.window().run_command("close_file")
+        self.view = None
+
+        self.assertRaises(ValueError, self.stream.read, None)
+        self.assertRaises(ValueError, self.stream.readline)
+        self.assertRaises(ValueError, self.stream.write, "\n")
+        self.assertRaises(ValueError, self.stream.clear)
+        self.assertRaises(ValueError, self.stream.seek, 0)
+        self.assertRaises(ValueError, self.stream.seek_start)
+        self.assertRaises(ValueError, self.stream.seek_end)
+        self.assertRaises(ValueError, self.stream.tell)

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -110,3 +110,23 @@ class TestViewStream(TestCase):
 
     def test_unsupported(self):
         self.assertRaises(UnsupportedOperation, self.stream.detach)
+
+    def test_selection_guard(self):
+        sel = self.view.sel()
+        sel.clear()
+        self.assertRaises(ValueError, self.stream.write, "\n")
+        sel.add(0)
+        self.stream.write("\n")
+        sel.add(0)
+        self.assertRaises(ValueError, self.stream.write, "\n")
+        sel.clear()
+        sel.add(sublime.Region(0, 1))
+        self.assertRaises(ValueError, self.stream.write, "\n")
+
+    # TODO how to invalidate a view?
+    # def test_validity_guard(self):
+    #     self.view.set_scratch(True)
+    #     self.view.window().focus_view(self.view)
+    #     self.view.window().run_command("close_file")
+    #     self.view = None
+    #     self.assertRaises(ValueError, self.stream.write, "\n")


### PR DESCRIPTION
Had this idea while reviewing whatever PR it was that added the checks. Initially I had each check as a generator, but then I realized I'd end up wrapping a method up to 3 times and that didn't seem right, so I rewrote the guards into normal checks (that raise exceptions) and added a "meta" guard that these checks are passed to. Also added context manager support to unset the read-only flag.

I guess this PR is quite controversial, so let me know what you think.

Advantages:
- Communicates more clearly what state invariants are required for a method to run successfully.
- Gets rid of internal functions that were wrapped with `_wrap_read_only`.

Disadvantages:
- Higher complexity and less obvious for developers not used to decorators.