### PR TITLE
Added view_utils.

### DIFF
--- a/st3/sublime_lib/encodings.py
+++ b/st3/sublime_lib/encodings.py
@@ -1,0 +1,86 @@
+from codecs import lookup
+
+__all__ = ['from_sublime', 'to_sublime']
+
+
+def from_sublime(name):
+    return SUBLIME_TO_STANDARD.get(name, None)
+
+
+def to_sublime(name):
+    return STANDARD_TO_SUBLIME.get(lookup(name).name, None)
+
+
+SUBLIME_TO_STANDARD = {  # noqa: E121
+   "UTF-8": "utf-8",
+   "UTF-8 with BOM": "utf-8-sig",
+   "UTF-16 LE": "utf-16-le",
+   "UTF-16 LE with BOM": "utf-16",
+   "UTF-16 BE": "utf-16-be",
+   "UTF-16 BE with BOM": "utf-16",
+   "Western (Windows 1252)": "cp1252",
+   "Western (ISO 8859-1)": "iso8859-1",
+   "Western (ISO 8859-3)": "iso8859-3",
+   "Western (ISO 8859-15)": "iso8859-15",
+   "Western (Mac Roman)": "mac-roman",
+   "DOS (CP 437)": "cp437",
+   "Arabic (Windows 1256)": "cp1256",
+   "Arabic (ISO 8859-6)": "iso8859-6",
+   "Baltic (Windows 1257)": "cp1257",
+   "Baltic (ISO 8859-4)": "iso8859-4",
+   "Celtic (ISO 8859-14)": "iso8859-14",
+   "Central European (Windows 1250)": "cp1250",
+   "Central European (ISO 8859-2)": "iso8859-2",
+   "Cyrillic (Windows 1251)": "cp1251",
+   "Cyrillic (Windows 866)": "cp866",
+   "Cyrillic (ISO 8859-5)": "iso8859-5",
+   "Cyrillic (KOI8-R)": "koi8-r",
+   "Cyrillic (KOI8-U)": "koi8-u",
+   "Estonian (ISO 8859-13)": "iso8859-13",
+   "Greek (Windows 1253)": "cp1253",
+   "Greek (ISO 8859-7)": "iso8859-7",
+   "Hebrew (Windows 1255)": "cp1255",
+   "Hebrew (ISO 8859-8)": "iso8859-8",
+   "Nordic (ISO 8859-10)": "iso8859-10",
+   "Romanian (ISO 8859-16)": "iso8859-16",
+   "Turkish (Windows 1254)": "cp1254",
+   "Turkish (ISO 8859-9)": "iso8859-9",
+   "Vietnamese (Windows 1258)": "cp1258",
+}
+
+
+STANDARD_TO_SUBLIME = {  # noqa: E121
+   "cp1258": "Vietnamese (Windows 1258)",
+   "cp1250": "Central European (Windows 1250)",
+   "cp1251": "Cyrillic (Windows 1251)",
+   "cp1252": "Western (Windows 1252)",
+   "cp1253": "Greek (Windows 1253)",
+   "cp1254": "Turkish (Windows 1254)",
+   "cp1255": "Hebrew (Windows 1255)",
+   "cp1256": "Arabic (Windows 1256)",
+   "cp1257": "Baltic (Windows 1257)",
+   "cp437": "DOS (CP 437)",
+   "cp866": "Cyrillic (Windows 866)",
+   "iso8859-1": "Western (ISO 8859-1)",
+   "iso8859-2": "Central European (ISO 8859-2)",
+   "iso8859-3": "Western (ISO 8859-3)",
+   "iso8859-4": "Baltic (ISO 8859-4)",
+   "iso8859-5": "Cyrillic (ISO 8859-5)",
+   "iso8859-6": "Arabic (ISO 8859-6)",
+   "iso8859-7": "Greek (ISO 8859-7)",
+   "iso8859-8": "Hebrew (ISO 8859-8)",
+   "iso8859-9": "Turkish (ISO 8859-9)",
+   "iso8859-10": "Nordic (ISO 8859-10)",
+   "iso8859-13": "Estonian (ISO 8859-13)",
+   "iso8859-14": "Celtic (ISO 8859-14)",
+   "iso8859-15": "Western (ISO 8859-15)",
+   "iso8859-16": "Romanian (ISO 8859-16)",
+   "koi8-r": "Cyrillic (KOI8-R)",
+   "koi8-u": "Cyrillic (KOI8-U)",
+   "mac-roman": "Western (Mac Roman)",
+   "utf-16": "UTF-16 LE with BOM",
+   "utf-16-be": "UTF-16 BE",
+   "utf-16-le": "UTF-16 LE",
+   "utf-8": "UTF-8",
+   "utf-8-sig": "UTF-8 with BOM",
+}

--- a/st3/sublime_lib/encodings.py
+++ b/st3/sublime_lib/encodings.py
@@ -50,7 +50,7 @@ SUBLIME_TO_STANDARD = {  # noqa: E121
 
 
 STANDARD_TO_SUBLIME = {  # noqa: E121
-   standard_name: sublime_name
-   for sublime_name, standard_name in SUBLIME_TO_STANDARD.items()
+    standard_name: sublime_name
+    for sublime_name, standard_name in SUBLIME_TO_STANDARD.items()
 }
 STANDARD_TO_SUBLIME['utf-16'] = 'UTF-16 LE with BOM'

--- a/st3/sublime_lib/encodings.py
+++ b/st3/sublime_lib/encodings.py
@@ -50,37 +50,7 @@ SUBLIME_TO_STANDARD = {  # noqa: E121
 
 
 STANDARD_TO_SUBLIME = {  # noqa: E121
-   "cp1258": "Vietnamese (Windows 1258)",
-   "cp1250": "Central European (Windows 1250)",
-   "cp1251": "Cyrillic (Windows 1251)",
-   "cp1252": "Western (Windows 1252)",
-   "cp1253": "Greek (Windows 1253)",
-   "cp1254": "Turkish (Windows 1254)",
-   "cp1255": "Hebrew (Windows 1255)",
-   "cp1256": "Arabic (Windows 1256)",
-   "cp1257": "Baltic (Windows 1257)",
-   "cp437": "DOS (CP 437)",
-   "cp866": "Cyrillic (Windows 866)",
-   "iso8859-1": "Western (ISO 8859-1)",
-   "iso8859-2": "Central European (ISO 8859-2)",
-   "iso8859-3": "Western (ISO 8859-3)",
-   "iso8859-4": "Baltic (ISO 8859-4)",
-   "iso8859-5": "Cyrillic (ISO 8859-5)",
-   "iso8859-6": "Arabic (ISO 8859-6)",
-   "iso8859-7": "Greek (ISO 8859-7)",
-   "iso8859-8": "Hebrew (ISO 8859-8)",
-   "iso8859-9": "Turkish (ISO 8859-9)",
-   "iso8859-10": "Nordic (ISO 8859-10)",
-   "iso8859-13": "Estonian (ISO 8859-13)",
-   "iso8859-14": "Celtic (ISO 8859-14)",
-   "iso8859-15": "Western (ISO 8859-15)",
-   "iso8859-16": "Romanian (ISO 8859-16)",
-   "koi8-r": "Cyrillic (KOI8-R)",
-   "koi8-u": "Cyrillic (KOI8-U)",
-   "mac-roman": "Western (Mac Roman)",
-   "utf-16": "UTF-16 LE with BOM",
-   "utf-16-be": "UTF-16 BE",
-   "utf-16-le": "UTF-16 LE",
-   "utf-8": "UTF-8",
-   "utf-8-sig": "UTF-8 with BOM",
+   standard_name: sublime_name
+   for sublime_name, standard_name in SUBLIME_TO_STANDARD.items()
 }
+STANDARD_TO_SUBLIME['utf-16'] = 'UTF-16 LE with BOM'

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -1,5 +1,5 @@
 from .view_stream import ViewStream
-from .view_utils import set_view_options
+from .view_utils import set_view_options, validate_view_options
 
 
 class OutputPanel(ViewStream):
@@ -8,6 +8,8 @@ class OutputPanel(ViewStream):
         force_writes=False,
         **kwargs
     ):
+        validate_view_options(kwargs)
+
         super().__init__(
             window.get_output_panel(name),
             force_writes=force_writes

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -1,4 +1,5 @@
 from .view_stream import ViewStream
+from .view_utils import set_view_options
 
 
 class OutputPanel(ViewStream):
@@ -16,13 +17,7 @@ class OutputPanel(ViewStream):
         self.window = window
         self.name = name
 
-        if settings is not None:
-            view_settings = self.view.settings()
-            for key, value in settings.items():
-                view_settings.set(key, value)
-
-        if read_only is not None:
-            self.view.set_read_only(read_only)
+        set_view_options(self.view, settings=settings, read_only=read_only)
 
     @property
     def full_name(self):

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -6,8 +6,7 @@ class OutputPanel(ViewStream):
     def __init__(
         self, window, name, *,
         force_writes=False,
-        settings=None,
-        read_only=None
+        **kwargs
     ):
         super().__init__(
             window.get_output_panel(name),
@@ -17,7 +16,7 @@ class OutputPanel(ViewStream):
         self.window = window
         self.name = name
 
-        set_view_options(self.view, settings=settings, read_only=read_only)
+        set_view_options(self.view, **kwargs)
 
     @property
     def full_name(self):

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -1,0 +1,37 @@
+from .syntax import get_syntax_for_scope
+
+
+def new_view(window, **kwargs):
+    view = window.new_file()
+    set_view_options(view, **kwargs)
+    return view
+
+
+def set_view_options(
+    view, *,
+    name=None,
+    settings=None,
+    read_only=None,
+    scratch=None,
+    syntax=None,
+    scope=None
+):
+    if name is not None:
+        view.set_name(name)
+
+    if settings is not None:
+        view_settings = view.settings()
+        for key, value in settings.items():
+            view_settings.set(key, value)
+
+    if read_only is not None:
+        view.set_read_only(read_only)
+
+    if scratch is not None:
+        view.set_scratch(scratch)
+
+    if scope is not None:
+        view.assign_syntax(get_syntax_for_scope(scope))
+
+    if syntax is not None:
+        view.assign_syntax(syntax)

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -102,7 +102,7 @@ def set_view_options(
         view.set_name(name)
 
     if content is not None:
-        view.run_command('insert', {'characters': content})
+        view.run_command('append', {'characters': content})
 
     if settings is not None:
         view_settings = view.settings()

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -8,6 +8,44 @@ __all__ = ['new_view', 'close_view']
 
 
 def new_view(window, **kwargs):
+    """Open a new view in the given window, returning the View object.
+
+    This function takes many optional keyword arguments:
+
+    content:
+        Text to be inserted into the new view. The text will be inserted even
+        if the `read_only` option is True.
+
+    encoding:
+        The encoding that the view should use when saving.
+
+    name:
+        The name of the view. This will be shown as the title of the view's tab.
+
+    overwrite:
+        If True, the view will be in overwrite mode.
+
+    read_only:
+        If True, the view will be read-only.
+
+    scope:
+        A scope name. The view will be assigned a syntax definition that
+        corresponds to the given scope (as determined by
+        sublime_lib.syntax.get_syntax_for_scope). Exclusive with the `syntax`
+        option.
+
+    scratch:
+        If True, the view will be a scratch buffer. The user will not be
+        prompted to save the view before closing it.
+
+    settings:
+        A dictionary of names and values that will be applied to the new view's
+        Settings object.
+
+    syntax:
+        The resource path of a syntax definition that the view will use.
+        Exclusive with the `scope` option.
+    """
     validate_view_options(kwargs)
 
     view = window.new_file()
@@ -16,6 +54,13 @@ def new_view(window, **kwargs):
 
 
 def close_view(view, *, force=False):
+    """
+    Closes the given view. If the `force` argument is True, then any unsaved
+    changes will be lost. Otherwise, if there are unsaved changes, ValueError
+    will be raised.
+
+    If the view is invalid (e.g. already closed), `close_view` will do nothing.
+    """
     if not view.is_valid():
         return
 

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -1,14 +1,27 @@
+import inspect
+
 from .syntax import get_syntax_for_scope
 from .encodings import to_sublime
 
 
+__all__ = ['new_view']
+
+
 def new_view(window, **kwargs):
-    if 'scope' in kwargs and 'syntax' in kwargs:
-        raise TypeError('The "syntax" and "scope" arguments are exclusive.')
+    validate_view_options(kwargs)
 
     view = window.new_file()
     set_view_options(view, **kwargs)
     return view
+
+
+def validate_view_options(options):
+    unknown = set(options) - VIEW_OPTIONS
+    if unknown:
+        raise ValueError('Unknown view options: %s.' % ', '.join(list(unknown)))
+
+    if 'scope' in options and 'syntax' in options:
+        raise ValueError('The "syntax" and "scope" arguments are exclusive.')
 
 
 def set_view_options(
@@ -51,3 +64,10 @@ def set_view_options(
 
     if encoding is not None:
         view.set_encoding(to_sublime(encoding))
+
+
+VIEW_OPTIONS = {
+    name
+    for name, param in inspect.signature(set_view_options).parameters.items()
+    if param.kind == inspect.Parameter.KEYWORD_ONLY
+}

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -4,7 +4,7 @@ from .syntax import get_syntax_for_scope
 from .encodings import to_sublime
 
 
-__all__ = ['new_view']
+__all__ = ['new_view', 'close_view']
 
 
 def new_view(window, **kwargs):
@@ -13,6 +13,23 @@ def new_view(window, **kwargs):
     view = window.new_file()
     set_view_options(view, **kwargs)
     return view
+
+
+def close_view(view, *, force=False):
+    if not view.is_valid():
+        return
+
+    if view.window() is None:
+        raise ValueError('The view has no associated window.')
+
+    if view.is_dirty() and not view.is_scratch():
+        if force:
+            view.set_scratch(True)
+        else:
+            raise ValueError('The view has unsaved changes.')
+
+    view.window().focus_view(view)
+    view.window().run_command("close_file")
 
 
 def validate_view_options(options):

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -1,7 +1,11 @@
 from .syntax import get_syntax_for_scope
+from .encodings import to_sublime
 
 
 def new_view(window, **kwargs):
+    if 'scope' in kwargs and 'syntax' in kwargs:
+        raise TypeError('The "syntax" and "scope" arguments are exclusive.')
+
     view = window.new_file()
     set_view_options(view, **kwargs)
     return view
@@ -13,11 +17,17 @@ def set_view_options(
     settings=None,
     read_only=None,
     scratch=None,
+    overwrite=None,
     syntax=None,
-    scope=None
+    scope=None,
+    encoding=None,
+    content=None
 ):
     if name is not None:
         view.set_name(name)
+
+    if content is not None:
+        view.run_command('insert', {'characters': content})
 
     if settings is not None:
         view_settings = view.settings()
@@ -30,8 +40,14 @@ def set_view_options(
     if scratch is not None:
         view.set_scratch(scratch)
 
+    if overwrite is not None:
+        view.set_overwrite_status(overwrite)
+
     if scope is not None:
         view.assign_syntax(get_syntax_for_scope(scope))
 
     if syntax is not None:
         view.assign_syntax(syntax)
+
+    if encoding is not None:
+        view.set_encoding(to_sublime(encoding))

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -62,9 +62,17 @@ class TestViewUtils(TestCase):
 
         self.assertTrue(self.view.scope_name(0).startswith('source.js'))
 
+    def test_unknown_args(self):
+        self.assertRaises(
+            ValueError,
+            new_view,
+            self.window,
+            bogus_arg="Hello, World!"
+        )
+
     def test_syntax_scope_exclusive(self):
         self.assertRaises(
-            TypeError,
+            ValueError,
             new_view,
             self.window,
             scope='source.js',

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -23,6 +23,7 @@ class TestViewUtils(TestCase):
         self.assertEquals(self.view.name(), '')
         self.assertFalse(self.view.is_read_only())
         self.assertFalse(self.view.is_scratch())
+        self.assertFalse(self.view.overwrite_status())
 
         self.assertEquals(self.view.scope_name(0).strip(), 'text.plain')
 
@@ -41,6 +42,11 @@ class TestViewUtils(TestCase):
 
         self.assertTrue(self.view.is_scratch())
 
+    def test_overwrite(self):
+        self.view = new_view(self.window, overwrite=True)
+
+        self.assertTrue(self.view.overwrite_status())
+
     def test_settings(self):
         self.view = new_view(self.window, settings={
             'example_setting': 'Hello, World!',
@@ -55,3 +61,33 @@ class TestViewUtils(TestCase):
         self.view = new_view(self.window, scope='source.js')
 
         self.assertTrue(self.view.scope_name(0).startswith('source.js'))
+
+    def test_syntax_scope_exclusive(self):
+        self.assertRaises(
+            TypeError,
+            new_view,
+            self.window,
+            scope='source.js',
+            syntax='Packages/JavaScript/JavaScript.sublime-syntax'
+        )
+
+    def test_encoding(self):
+        self.view = new_view(self.window, encoding='utf-16')
+
+        self.assertEquals(self.view.encoding(), "UTF-16 LE with BOM")
+
+    def test_content(self):
+        self.view = new_view(self.window, content="Hello, World!")
+
+        self.assertEquals(
+            self.view.substr(sublime.Region(0, self.view.size())),
+            "Hello, World!"
+        )
+
+    def test_content_read_only(self):
+        self.view = new_view(self.window, content="Hello, World!", read_only=True)
+
+        self.assertEquals(
+            self.view.substr(sublime.Region(0, self.view.size())),
+            "Hello, World!"
+        )

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -1,5 +1,5 @@
 import sublime
-from sublime_lib.view_utils import new_view
+from sublime_lib.view_utils import new_view, close_view
 
 from unittest import TestCase
 
@@ -11,9 +11,7 @@ class TestViewUtils(TestCase):
 
     def tearDown(self):
         if getattr(self, 'view', None):
-            self.view.set_scratch(True)
-            self.view.window().focus_view(self.view)
-            self.view.window().run_command("close_file")
+            close_view(self.view, force=True)
 
     def test_new_view(self):
         self.view = new_view(self.window)
@@ -99,3 +97,25 @@ class TestViewUtils(TestCase):
             self.view.substr(sublime.Region(0, self.view.size())),
             "Hello, World!"
         )
+
+    def test_close_view(self):
+        self.view = new_view(self.window)
+
+        close_view(self.view)
+        self.assertFalse(self.view.is_valid())
+
+    def test_close_unsaved(self):
+        self.view = new_view(self.window, content="Hello, World!")
+
+        self.assertRaises(ValueError, close_view, self.view)
+        self.assertTrue(self.view.is_valid())
+
+        close_view(self.view, force=True)
+        self.assertFalse(self.view.is_valid())
+
+    def test_close_panel_error(self):
+        view = self.window.create_output_panel('sublime_lib-TestViewUtils')
+
+        self.assertRaises(ValueError, close_view, view)
+
+        self.window.destroy_output_panel('sublime_lib-TestViewUtils')

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -1,0 +1,57 @@
+import sublime
+from sublime_lib.view_utils import new_view
+
+from unittest import TestCase
+
+
+class TestViewUtils(TestCase):
+
+    def setUp(self):
+        self.window = sublime.active_window()
+
+    def tearDown(self):
+        if getattr(self, 'view', None):
+            self.view.set_scratch(True)
+            self.view.window().focus_view(self.view)
+            self.view.window().run_command("close_file")
+
+    def test_new_view(self):
+        self.view = new_view(self.window)
+
+        self.assertTrue(self.view.is_valid())
+
+        self.assertEquals(self.view.name(), '')
+        self.assertFalse(self.view.is_read_only())
+        self.assertFalse(self.view.is_scratch())
+
+        self.assertEquals(self.view.scope_name(0).strip(), 'text.plain')
+
+    def test_name(self):
+        self.view = new_view(self.window, name='My Name')
+
+        self.assertEquals(self.view.name(), 'My Name')
+
+    def test_read_only(self):
+        self.view = new_view(self.window, read_only=True)
+
+        self.assertTrue(self.view.is_read_only())
+
+    def test_scratch(self):
+        self.view = new_view(self.window, scratch=True)
+
+        self.assertTrue(self.view.is_scratch())
+
+    def test_settings(self):
+        self.view = new_view(self.window, settings={
+            'example_setting': 'Hello, World!',
+        })
+
+        self.assertEquals(
+            self.view.settings().get('example_setting'),
+            'Hello, World!'
+        )
+
+    def test_scope(self):
+        self.view = new_view(self.window, scope='source.js')
+
+        self.assertTrue(self.view.scope_name(0).startswith('source.js'))


### PR DESCRIPTION
`sublime_lib.view_utils.new_view` is a useful shorthand way to create a new view. You can specify view name, syntax, settings, read-only, and more. The implementation is in `set_view_options`, which is also used in `OutputPanel`.

Is there reason to expose more options in `OutputPanel`? Are the missing options useful? I seem to recall that calling `assign_syntax` on an output panel causes weird things to happen, and the `name` and `scratch` options don't seem relevant.