### PR TITLE
Fixed bugs in ViewStream.write.

### DIFF
--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -100,8 +100,13 @@ class ViewStream(TextIOBase):
         characters inserted. The string will be inserted immediately before the
         cursor.
         """
-        self.view.run_command('insert', {'characters': s})
-        return len(s)
+        # This is a hack to get around auto-indentation.
+        old_size = self.view.size()
+        self.view.run_command('insert_snippet', {
+            'contents': '$sublime_lib__insert_text',
+            'sublime_lib__insert_text': s,
+        })
+        return self.view.size() - old_size
 
     def print(self, *objects, **kwargs):
         print(*objects, file=self, **kwargs)

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -99,6 +99,9 @@ class ViewStream(TextIOBase):
         """Insert the string <var>s</var> into the view and return the number of
         characters inserted. The string will be inserted immediately before the
         cursor.
+
+        Note: Because Sublime may convert tabs to spaces, the number of
+        characters inserted may not match the length of the argument.
         """
         # This is a hack to get around auto-indentation.
         old_size = self.view.size()

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -41,6 +41,19 @@ class TestViewStream(TestCase):
 
         self.assertContents("Top\nAfter Top\nHello, World!\nBottom\n")
 
+    def test_write_size(self):
+        text = "Hello\n\tWorld!"
+
+        size = self.stream.write(text)
+        self.assertEqual(size, self.stream.view.size())
+
+    def test_no_indent(self):
+        text = "Hello\n    World\n!"
+
+        self.stream.view.settings().set('auto_indent', True)
+        self.stream.write(text)
+        self.assertContents(text)
+
     def test_clear(self):
         self.stream.write("Some text")
         self.stream.clear()


### PR DESCRIPTION
The size returned from `write` is now measured, because it can be different than the length of the string argument.

In addition, the inserted text will not be auto-indented. This could conceivably be an option (like `force_write`).