### PR TITLE
Added new features to OutputPanel.

### DIFF
--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -6,12 +6,13 @@ class OutputPanel(ViewStream):
     def __init__(
         self, window, name, *,
         force_writes=False,
+        unlisted=False,
         **kwargs
     ):
         validate_view_options(kwargs)
 
         super().__init__(
-            window.get_output_panel(name),
+            window.create_output_panel(name, unlisted),
             force_writes=force_writes
         )
 
@@ -25,12 +26,23 @@ class OutputPanel(ViewStream):
         return "output.%s" % self.name
 
     @ViewStream.guard_validity
+    def is_visible(self):
+        return self.window.active_panel() == self.full_name
+
+    @ViewStream.guard_validity
     def show(self):
         self.window.run_command("show_panel", {"panel": self.full_name})
 
     @ViewStream.guard_validity
     def hide(self):
         self.window.run_command("hide_panel", {"panel": self.full_name})
+
+    @ViewStream.guard_validity
+    def toggle_visibility(self):
+        if self.is_visible():
+            self.hide()
+        else:
+            self.show()
 
     def destroy(self):
         self.window.destroy_output_panel(self.name)

--- a/tests/test_output_panel.py
+++ b/tests/test_output_panel.py
@@ -49,10 +49,22 @@ class TestOutputPanel(TestCase):
     def test_show_hide(self):
         self.panel.show()
 
+        self.assertTrue(self.panel.is_visible())
         self.assertEqual(self.window.active_panel(), self.panel.full_name)
 
         self.panel.hide()
 
+        self.assertFalse(self.panel.is_visible())
+        self.assertNotEqual(self.window.active_panel(), self.panel.full_name)
+
+        self.panel.toggle_visibility()
+
+        self.assertTrue(self.panel.is_visible())
+        self.assertEqual(self.window.active_panel(), self.panel.full_name)
+
+        self.panel.toggle_visibility()
+
+        self.assertFalse(self.panel.is_visible())
         self.assertNotEqual(self.window.active_panel(), self.panel.full_name)
 
     def test_exists(self):
@@ -69,3 +81,11 @@ class TestOutputPanel(TestCase):
 
         view_settings = self.panel.view.settings()
         self.assertEqual(view_settings.get("test_setting"), "Hello, World!")
+
+    def test_unlisted(self):
+        self.panel.destroy()
+        self.panel = OutputPanel(self.window, self.panel_name, unlisted=True)
+
+        self.panel.show()
+        self.assertTrue(self.panel.is_visible())
+        self.assertNotIn(self.panel.full_name, self.window.panels())


### PR DESCRIPTION
Add new methods `is_visible` and `toggle_visibility`. These would definitely be used by, e.g., SublimeLinter.

Use `create_output_panel` instead of `get_output_panel`. The latter is apparently deprecated. The former supports an `unlisted` parameter, and now so do we.

We should probably explicitly address what happens when the user creates a panel that already exists (i.e. whose name is the name of an existing panel). We could:

- Explicitly destroy the old panel, then create a new one.
- Re-use the existing view, but apply the given options.
- Raise an error.
- Any of the above depending on an argument.

I'm not quite sure what Sublime does in the present implementation -- specifically how it may differ from simply re-using the view. I do know that the `unlisted` argument is ignored if a panel by the given name already exists.