### PR TITLE
Split output panel creation behavior into constructor and `create`.

### DIFF
--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -3,23 +3,32 @@ from .view_utils import set_view_options, validate_view_options
 
 
 class OutputPanel(ViewStream):
-    def __init__(
-        self, window, name, *,
+    @staticmethod
+    def create(
+        window, name, *,
         force_writes=False,
         unlisted=False,
         **kwargs
     ):
         validate_view_options(kwargs)
 
+        window.destroy_output_panel(name)
+        view = window.create_output_panel(name, unlisted)
+        set_view_options(view, **kwargs)
+
+        return OutputPanel(window, name, force_writes=force_writes)
+
+    def __init__(
+        self, window, name, *,
+        force_writes=False
+    ):
         super().__init__(
-            window.create_output_panel(name, unlisted),
+            window.find_output_panel(name),
             force_writes=force_writes
         )
 
         self.window = window
         self.name = name
-
-        set_view_options(self.view, **kwargs)
 
     @property
     def full_name(self):

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -3,8 +3,9 @@ from .view_utils import set_view_options, validate_view_options
 
 
 class OutputPanel(ViewStream):
-    @staticmethod
+    @classmethod
     def create(
+        cls,
         window, name, *,
         force_writes=False,
         unlisted=False,
@@ -16,16 +17,17 @@ class OutputPanel(ViewStream):
         view = window.create_output_panel(name, unlisted)
         set_view_options(view, **kwargs)
 
-        return OutputPanel(window, name, force_writes=force_writes)
+        return cls(window, name, force_writes=force_writes)
 
     def __init__(
         self, window, name, *,
         force_writes=False
     ):
-        super().__init__(
-            window.find_output_panel(name),
-            force_writes=force_writes
-        )
+        view = window.find_output_panel(name)
+        if view is None:
+            raise ValueError('Output panel "%s" does not exist.' % name)
+
+        super().__init__(view, force_writes=force_writes)
 
         self.window = window
         self.name = name

--- a/tests/test_output_panel.py
+++ b/tests/test_output_panel.py
@@ -13,7 +13,8 @@ class TestOutputPanel(TestCase):
         self.panel_name = "test_panel"
 
     def tearDown(self):
-        self.panel.destroy()
+        if getattr(self, 'panel', None):
+            self.panel.destroy()
 
         if self.panel_to_restore:
             self.window.run_command("show_panel", {"panel": self.panel_to_restore})
@@ -104,3 +105,6 @@ class TestOutputPanel(TestCase):
 
         self.panel.destroy()
         self.assertRaises(ValueError, other.tell)
+
+    def test_init_nonexistent_error(self):
+        self.assertRaises(ValueError, OutputPanel, self.window, 'does_not_exist')

--- a/tests/test_output_panel.py
+++ b/tests/test_output_panel.py
@@ -11,7 +11,6 @@ class TestOutputPanel(TestCase):
         self.panel_to_restore = self.window.active_panel()
 
         self.panel_name = "test_panel"
-        self.panel = OutputPanel(self.window, self.panel_name)
 
     def tearDown(self):
         self.panel.destroy()
@@ -27,6 +26,8 @@ class TestOutputPanel(TestCase):
         )
 
     def test_stream_operations(self):
+        self.panel = OutputPanel.create(self.window, self.panel_name)
+
         self.panel.write("Hello, ")
         self.panel.print("World!")
 
@@ -42,11 +43,15 @@ class TestOutputPanel(TestCase):
         self.assertContents("Top\nAfter Top\nHello, World!\nBottom\n")
 
     def test_clear(self):
+        self.panel = OutputPanel.create(self.window, self.panel_name)
+
         self.panel.write("Some text")
         self.panel.clear()
         self.assertContents("")
 
     def test_show_hide(self):
+        self.panel = OutputPanel.create(self.window, self.panel_name)
+
         self.panel.show()
 
         self.assertTrue(self.panel.is_visible())
@@ -68,14 +73,16 @@ class TestOutputPanel(TestCase):
         self.assertNotEqual(self.window.active_panel(), self.panel.full_name)
 
     def test_exists(self):
+        self.panel = OutputPanel.create(self.window, self.panel_name)
         self.assertIsNotNone(self.window.find_output_panel(self.panel.name))
 
     def test_destroy(self):
+        self.panel = OutputPanel.create(self.window, self.panel_name)
         self.panel.destroy()
         self.assertIsNone(self.window.find_output_panel(self.panel.name))
 
     def test_settings(self):
-        self.panel = OutputPanel(self.window, self.panel_name, settings={
+        self.panel = OutputPanel.create(self.window, self.panel_name, settings={
             "test_setting": "Hello, World!"
         })
 
@@ -83,9 +90,17 @@ class TestOutputPanel(TestCase):
         self.assertEqual(view_settings.get("test_setting"), "Hello, World!")
 
     def test_unlisted(self):
-        self.panel.destroy()
-        self.panel = OutputPanel(self.window, self.panel_name, unlisted=True)
+        self.panel = OutputPanel.create(self.window, self.panel_name, unlisted=True)
 
         self.panel.show()
         self.assertTrue(self.panel.is_visible())
         self.assertNotIn(self.panel.full_name, self.window.panels())
+
+    def test_attach(self):
+        self.panel = OutputPanel.create(self.window, self.panel_name, unlisted=True)
+
+        other = OutputPanel(self.window, self.panel_name)
+        self.assertEqual(self.panel.view.id(), other.view.id())
+
+        self.panel.destroy()
+        self.assertRaises(ValueError, other.tell)


### PR DESCRIPTION
Continuing the discussion from #28.

This is a minimal-ish approach; I haven't created a `find` method.

Upon consideration, the constructor *doesn't* need to take the window and name -- not quite. We could instead give it the *view* and name, and it can get the window from there. This would be as similar as possible to the parent, which only takes a view, and it would save the call to `find_output_panel`. In this scenario, it would definitely make sense to provide a static `find` method taking a window argument.

Is there a sensible way to get the panel name from a view? The only way I can think of is to call `find_output_panel` for each name in `window.panels()`, which seems clumsy. On the other hand, it would be easy to verify a given (view, name) pair by checking that `view.window().find_output_panel(name) is view`.