### PR TITLE
Implemented default settings logic in new DefaultFancySettings class.

### DIFF
--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -1,5 +1,6 @@
 from .fancy_settings import FancySettings  # noqa: F401
 from .fancy_settings import NamedFancySettings  # noqa: F401
+from .fancy_settings import DefaultFancySettings  # noqa: F401
 from .view_buffer import ViewBuffer  # noqa: F401
 from .view_stream import ViewStream  # noqa: F401
 from .output_panel import OutputPanel  # noqa: F401

--- a/st3/sublime_lib/fancy_settings.py
+++ b/st3/sublime_lib/fancy_settings.py
@@ -172,7 +172,7 @@ class NamedFancySettings(FancySettings):
 
 
 class DefaultFancySettings(FancySettings):
-    def __init__(self, settings, defaults={}):
+    def __init__(self, settings, defaults):
         """
         Return a new FancySettings wrapping a given Settings object *settings*.
         """
@@ -180,4 +180,4 @@ class DefaultFancySettings(FancySettings):
         self.defaults = defaults
 
     def __missing__(self, key):
-        return self.defaults[key]
+        return self.setdefault(key, self.defaults[key])

--- a/st3/sublime_lib/fancy_settings.py
+++ b/st3/sublime_lib/fancy_settings.py
@@ -38,19 +38,21 @@ class FancySettings():
     - values()
     """
 
-    def __init__(self, settings, defaults={}):
+    def __init__(self, settings):
         """
         Return a new FancySettings wrapping a given Settings object *settings*.
         """
         self.settings = settings
-        self.defaults = defaults
 
     def __getitem__(self, key):
         """Return the setting named *key*. Raises a KeyError if there is no such setting."""
-        if key in self or key in self.defaults:
+        if key in self:
             return self.get(key)
         else:
-            raise KeyError(key)
+            return self.__missing__(key)
+
+    def __missing__(self, key):
+        raise KeyError(key)
 
     def __setitem__(self, key, value):
         """Set `d[key]` to *value*."""
@@ -73,7 +75,7 @@ class FancySettings():
         default is not given, it defaults to None, so that this method never
         raises a KeyError.
         """
-        return self.settings.get(key, self.defaults.get(key, default))
+        return self.settings.get(key, default)
 
     def pop(self, key, default=NOT_GIVEN):
         """
@@ -158,12 +160,24 @@ class NamedFancySettings(FancySettings):
     file.
     """
 
-    def __init__(self, name, defaults={}):
+    def __init__(self, name):
         """Return a new NamedFancySettings corresponding to the given name."""
 
-        super().__init__(sublime.load_settings(name), defaults)
+        super().__init__(sublime.load_settings(name))
         self.name = name
 
     def save(self):
         """Flushes any in-memory changes to the named settings object to disk."""
         sublime.save_settings(self.name)
+
+
+class DefaultFancySettings(FancySettings):
+    def __init__(self, settings, defaults={}):
+        """
+        Return a new FancySettings wrapping a given Settings object *settings*.
+        """
+        super().__init__(settings)
+        self.defaults = defaults
+
+    def __missing__(self, key):
+        return self.defaults[key]

--- a/tests/test_fancy_settings.py
+++ b/tests/test_fancy_settings.py
@@ -1,5 +1,6 @@
 import sublime
 from sublime_lib import FancySettings
+from sublime_lib import DefaultFancySettings
 
 from unittest import TestCase
 
@@ -158,3 +159,27 @@ class TestFancySettingsSubscription(TestCase):
             'example_1': 10,
             'example_2': 2
         })
+
+
+class TestDefaultFancySettings(TestCase):
+
+    def setUp(self):
+        self.view = sublime.active_window().new_file()
+        self.settings = self.view.settings()
+
+    def tearDown(self):
+        if self.view:
+            self.view.set_scratch(True)
+            self.view.window().focus_view(self.view)
+            self.view.window().run_command("close_file")
+
+    def test_get_default(self):
+        self.fancy = DefaultFancySettings(self.settings, {
+            'example_1': 'Hello, World!',
+        })
+
+        self.assertEqual(self.fancy['example_1'], 'Hello, World!')
+        self.fancy['example_1'] = 'Goodbye, World!'
+        self.assertEqual(self.fancy['example_1'], 'Goodbye, World!')
+
+        self.assertRaises(KeyError, self.fancy.__getitem__, 'example_2')

--- a/tests/test_fancy_settings.py
+++ b/tests/test_fancy_settings.py
@@ -179,7 +179,11 @@ class TestDefaultFancySettings(TestCase):
         })
 
         self.assertEqual(self.fancy['example_1'], 'Hello, World!')
+
         self.fancy['example_1'] = 'Goodbye, World!'
         self.assertEqual(self.fancy['example_1'], 'Goodbye, World!')
+
+        self.fancy.__missing__('example_1')
+        self.assertEqual(self.fancy['example_1'], 'Hello, World!')
 
         self.assertRaises(KeyError, self.fancy.__getitem__, 'example_2')


### PR DESCRIPTION
This implementation is inspired by `defaultdict`, and I think it might be more consistent with existing practice.

When you index a `FancySettings` with a nonexistent key, it will call `self.__missing__(key)`  and return the result. The base implementation simply raises KeyError. A new `DefaultFancySettings` subclass takes a `defaults` parameter in its constructor and overrides `__missing__` to set and return a default value. This is basically how `defaultdict` works (although that class takes a `default_factory` function, not a `defaults` dict).

The major difference is that `NamedFancySettings` doesn't accept manual defaults, but the preferred way to supply defaults to a named settings object is to provide a default settings file. View-specific settings and other "anonymous" settings objects can use `DefaultFancySettings` instead.