### PR TITLE
Renamed FancySettings to SettingsDict.

### DIFF
--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -1,6 +1,6 @@
-from .fancy_settings import FancySettings  # noqa: F401
-from .fancy_settings import NamedFancySettings  # noqa: F401
-from .fancy_settings import DefaultFancySettings  # noqa: F401
+from .settings_dict import SettingsDict  # noqa: F401
+from .settings_dict import NamedSettingsDict  # noqa: F401
+from .settings_dict import DefaultSettingsDict  # noqa: F401
 from .view_buffer import ViewBuffer  # noqa: F401
 from .view_stream import ViewStream  # noqa: F401
 from .output_panel import OutputPanel  # noqa: F401

--- a/st3/sublime_lib/settings_dict.py
+++ b/st3/sublime_lib/settings_dict.py
@@ -21,7 +21,7 @@ def ismapping(obj):
 NOT_GIVEN = {}
 
 
-class FancySettings():
+class SettingsDict():
     """
     Wraps a sublime.Settings object with a dict-like interface.
 
@@ -40,7 +40,7 @@ class FancySettings():
 
     def __init__(self, settings):
         """
-        Return a new FancySettings wrapping a given Settings object *settings*.
+        Return a new SettingsDict wrapping a given Settings object *settings*.
         """
         self.settings = settings
 
@@ -49,7 +49,7 @@ class FancySettings():
         Return the setting named *key*. Raises a KeyError if there is no such
         setting.
 
-        If a subclass of FancySettings defines a method `__missing__()` and
+        If a subclass of SettingsDict defines a method `__missing__()` and
         `key` is not present, the `d[key]` operation calls that method with the
         key `key` as argument. The `d[key]` operation then returns or raises
         whatever is returned or raised by the `__missing__(key)` call. No other
@@ -165,14 +165,14 @@ class FancySettings():
         self.settings.clear_on_change(key)
 
 
-class NamedFancySettings(FancySettings):
+class NamedSettingsDict(SettingsDict):
     """
     Wraps a `sublime.Settings` object corresponding to a `sublime-settings`
     file.
     """
 
     def __init__(self, name):
-        """Return a new NamedFancySettings corresponding to the given name."""
+        """Return a new NamedSettingsDict corresponding to the given name."""
 
         super().__init__(sublime.load_settings(name))
         self.name = name
@@ -182,9 +182,9 @@ class NamedFancySettings(FancySettings):
         sublime.save_settings(self.name)
 
 
-class DefaultFancySettings(FancySettings):
+class DefaultSettingsDict(SettingsDict):
     """
-    A subclass of FancySettings that accepts user-defined default values.
+    A subclass of SettingsDict that accepts user-defined default values.
 
     This class generally should not be used with named settings files. Instead,
     package developers should provide settings files populated with defaults.
@@ -192,7 +192,7 @@ class DefaultFancySettings(FancySettings):
 
     def __init__(self, settings, defaults):
         """
-        Return a new DefaultFancySettings wrapping a given Settings object
+        Return a new DefaultSettingsDict wrapping a given Settings object
         *settings*, with a given dict-like object *defaults* of default values.
         """
         super().__init__(settings)
@@ -206,7 +206,7 @@ class DefaultFancySettings(FancySettings):
         If looking up `key` in `defaults` raises an exception (such as a
         `KeyError`), this exception is propagated unchanged.
 
-        This method is called by the __getitem__() method of the FancySettings
+        This method is called by the __getitem__() method of the SettingsDict
         class when the requested key is not found; whatever it returns or
         raises is then returned or raised by __getitem__().
 

--- a/tests/test_named_settings_dict.py
+++ b/tests/test_named_settings_dict.py
@@ -1,5 +1,5 @@
 import sublime
-from sublime_lib import NamedFancySettings
+from sublime_lib import NamedSettingsDict
 
 import os
 from os import path
@@ -7,21 +7,21 @@ from os import path
 from unittesting import DeferrableTestCase
 
 
-class TestNamedFancySettings(DeferrableTestCase):
+class TestNamedSettingsDict(DeferrableTestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def setUp(self):
-        self.name = "_sublime_lib_NamedFancySettingsTest.sublime-settings"
+        self.name = "_sublime_lib_NamedSettingsDictTest.sublime-settings"
         self.settings_path = path.join(sublime.packages_path(), 'User', self.name)
-        self.fancy = NamedFancySettings(self.name)
+        self.fancy = NamedSettingsDict(self.name)
 
     def tearDown(self):
         if path.exists(self.settings_path):
             os.remove(self.settings_path)
 
     def test_named(self):
-        other = NamedFancySettings(self.name)
+        other = NamedSettingsDict(self.name)
 
         self.fancy["example_setting"] = "Hello, World!"
 

--- a/tests/test_settings_dict.py
+++ b/tests/test_settings_dict.py
@@ -1,16 +1,16 @@
 import sublime
-from sublime_lib import FancySettings
-from sublime_lib import DefaultFancySettings
+from sublime_lib import SettingsDict
+from sublime_lib import DefaultSettingsDict
 
 from unittest import TestCase
 
 
-class TestFancySettings(TestCase):
+class TestSettingsDict(TestCase):
 
     def setUp(self):
         self.view = sublime.active_window().new_file()
         self.settings = self.view.settings()
-        self.fancy = FancySettings(self.settings)
+        self.fancy = SettingsDict(self.settings)
 
     def tearDown(self):
         if self.view:
@@ -105,12 +105,12 @@ class TestFancySettings(TestCase):
         self.assertEqual(self.fancy['yzzyx'], 4)
 
 
-class TestFancySettingsSubscription(TestCase):
+class TestSettingsDictSubscription(TestCase):
 
     def setUp(self):
         self.view = sublime.active_window().new_file()
         self.settings = self.view.settings()
-        self.fancy = FancySettings(self.settings)
+        self.fancy = SettingsDict(self.settings)
 
     def tearDown(self):
         if self.view:
@@ -161,7 +161,7 @@ class TestFancySettingsSubscription(TestCase):
         })
 
 
-class TestDefaultFancySettings(TestCase):
+class TestDefaultSettingsDict(TestCase):
 
     def setUp(self):
         self.view = sublime.active_window().new_file()
@@ -174,7 +174,7 @@ class TestDefaultFancySettings(TestCase):
             self.view.window().run_command("close_file")
 
     def test_get_default(self):
-        self.fancy = DefaultFancySettings(self.settings, {
+        self.fancy = DefaultSettingsDict(self.settings, {
             'example_1': 'Hello, World!',
         })
 


### PR DESCRIPTION
Since we ended up basically implementing the `dict` interface, `SettingsDict` might be a more descriptive name than `FancySettings`. Looking for feedback.