### PR TITLE
Use undocumented View.close method in `close_view`.

### DIFF
--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -65,8 +65,7 @@ def close_view(view, *, force=False):
         else:
             raise ValueError('The view has unsaved changes.')
 
-    view.window().focus_view(view)
-    view.window().run_command("close_file")
+    view.close()
 
 
 def validate_view_options(options):

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -50,22 +50,17 @@ def close_view(view, *, force=False):
 
     If the view is invalid (e.g. already closed), do nothing.
 
-    :raise ValueError: if the view has no associated window (e.g. a panel).
     :raise ValueError: if the view has unsaved changes and `force` is not ``True``.
+    :raise ValueError: if the view is not closed for any other reason.
     """
-    if not view.is_valid():
-        return
-
-    if view.window() is None:
-        raise ValueError('The view has no associated window.')
-
     if view.is_dirty() and not view.is_scratch():
         if force:
             view.set_scratch(True)
         else:
             raise ValueError('The view has unsaved changes.')
 
-    view.close()
+    if not view.close():
+        raise ValueError('The view could not be closed.')
 
 
 def validate_view_options(options):

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -11,7 +11,10 @@ class TestViewUtils(TestCase):
 
     def tearDown(self):
         if getattr(self, 'view', None):
-            close_view(self.view, force=True)
+            try:
+                close_view(self.view, force=True)
+            except ValueError:
+                pass
 
     def test_new_view(self):
         self.view = new_view(self.window)

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -116,6 +116,12 @@ class TestViewUtils(TestCase):
         close_view(self.view, force=True)
         self.assertFalse(self.view.is_valid())
 
+    def test_close_closed_error(self):
+        self.view = new_view(self.window)
+
+        close_view(self.view)
+        self.assertRaises(ValueError, close_view, self.view)
+
     def test_close_panel_error(self):
         view = self.window.create_output_panel('sublime_lib-TestViewUtils')
 


### PR DESCRIPTION
Much better than the old approach.