### PR TITLE
Do not expose vendored enum library.

### DIFF
--- a/st3/sublime_lib/enum.py
+++ b/st3/sublime_lib/enum.py
@@ -1,6 +1,0 @@
-"""
-A port of Python 3.6's :mod:`enum` module.
-"""
-
-
-from .vendor.python.enum import *  # noqa: F401,F403

--- a/st3/sublime_lib/flags.py
+++ b/st3/sublime_lib/flags.py
@@ -1,7 +1,6 @@
 import sublime
 
-from .enum import IntEnum, IntFlag
-
+from .vendor.python.enum import IntEnum, IntFlag
 
 class DialogResult(IntEnum):
     CANCEL = sublime.DIALOG_CANCEL


### PR DESCRIPTION
Because there's already a dependency for this, there's no need to expose it here. Instead, we use the vendored version directly in `flags.py`.