### PR TITLE
Remove DefaultSettingsDict

### DIFF
--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -1,6 +1,5 @@
 from .settings_dict import SettingsDict  # noqa: F401
 from .settings_dict import NamedSettingsDict  # noqa: F401
-from .settings_dict import DefaultSettingsDict  # noqa: F401
 from .view_buffer import ViewBuffer  # noqa: F401
 from .view_stream import ViewStream  # noqa: F401
 from .output_panel import OutputPanel  # noqa: F401

--- a/st3/sublime_lib/settings_dict.py
+++ b/st3/sublime_lib/settings_dict.py
@@ -41,6 +41,10 @@ class SettingsDict():
     - :meth:`keys`
     - :meth:`popitem`
     - :meth:`values`
+
+    You can use :class:`collections.ChainMap` to chain a :class:`SettingsDict`
+    with other dict-like objects. If you do, calling the above unimplemented
+    methods on the :class:`~collections.ChainMap` will raise an error.
     """
 
     def __init__(self, settings):

--- a/st3/sublime_lib/settings_dict.py
+++ b/st3/sublime_lib/settings_dict.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from .collection_utils import projection
 
 
-__all__ = [ 'SettingsDict', 'NamedSettingsDict', 'DefaultSettingsDict' ]
+__all__ = ['SettingsDict', 'NamedSettingsDict']
 
 
 def isiterable(obj):
@@ -45,6 +45,10 @@ class SettingsDict():
 
     def __init__(self, settings):
         self.settings = settings
+
+    def __iter__(self):
+        """Raise NotImplementedError."""
+        raise NotImplementedError()
 
     def __getitem__(self, key):
         """
@@ -194,39 +198,3 @@ class NamedSettingsDict(SettingsDict):
     def save(self):
         """Flushes any in-memory changes to the named settings object to disk."""
         sublime.save_settings(self.name)
-
-
-class DefaultSettingsDict(SettingsDict):
-    """
-    A subclass of :class:`SettingsDict` that accepts user-defined default values.
-
-    This class generally should not be used with named settings files. Instead,
-    package developers should provide settings files populated with defaults.
-    """
-
-    def __init__(self, settings, defaults):
-        """
-        Return a new DefaultSettingsDict wrapping a given Settings object
-        `settings`, with a given dict-like object `defaults` of default values.
-        """
-        super().__init__(settings)
-        self.defaults = defaults
-
-    def __missing__(self, key):
-        """
-        Lookup the given `key` in this object's `defaults` attribute, insert
-        that value into this object for the `key`, and return that value.
-
-        If looking up `key` in `defaults` raises an exception (such as a
-        :exc:`KeyError`), this exception is propagated unchanged.
-
-        This method is called by the :meth:`__getitem__` method of the SettingsDict
-        class when the requested key is not found; whatever it returns or
-        raises is then returned or raised by :meth:`__getitem__`.
-
-        Note that __missing__() is not called for any operations besides
-        __getitem__(). This means that get() will, like normal dictionaries,
-        return None as a default rather than using defaults.
-        """
-        self[key] = self.defaults[key]
-        return self[key]


### PR DESCRIPTION
`collections.ChainMap` can be used instead of `DefaultSettingsDict`, so the latter is unnecessary.

`SettingsDict` now implements `__iter__`, raising [`NotImplementedError`](https://docs.python.org/3/library/exceptions.html#NotImplementedError). Formerly, calling `iter` on a `SettingsDict` would indirectly raise `TypeError`, which was confusing.

In principle, `NotImplementedError` is supposed to be used for methods that are supposed to be implemented in the future. The degree to which this describes `SettingDict.__iter__` depends on one's optimism that the Sublime API will someday permit this. Either way, I think that `NotImplementedError` is the clearest way to indicate that, unusually for a collection, `SettingsDict` is not iterable.

I've added tests checking the `NotImplementedError` and ensuring that `SettingsDict` works in a `ChainMap`.