### PR TITLE
Documented flags.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../../st3'))
 sys.path.insert(0, os.path.abspath('extensions'))
+sys.path.insert(0, os.path.abspath('mocks'))
 
 # -- Project information -----------------------------------------------------
 
@@ -43,7 +44,7 @@ extensions = [
     'sphinx.ext.intersphinx',
 ]
 
-autodoc_mock_imports = ["sublime", "sublime_plugin"]
+autodoc_mock_imports = ["sublime_plugin"]
 autodoc_default_flags = ["members"]
 autodoc_member_order = 'bysource'
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,6 @@ Welcome to sublime_lib's documentation!
 
    sublime_lib.collection_utils
    sublime_lib.encodings
-   sublime_lib.enum
    sublime_lib.flags
    sublime_lib.output_panel
    sublime_lib.settings_dict

--- a/docs/source/mocks/sublime.py
+++ b/docs/source/mocks/sublime.py
@@ -1,0 +1,16 @@
+from sphinx.ext.autodoc.importer import _MockObject
+
+import sys
+
+
+class SublimeMock:
+    Region = _MockObject()
+
+    def __getattr__(self, key):
+        if key.isupper():
+            return hash(key)
+        else:
+            raise AttributeError(key)
+
+
+sys.modules[__name__] = SublimeMock()

--- a/st3/sublime_lib/flags.py
+++ b/st3/sublime_lib/flags.py
@@ -1,14 +1,53 @@
+"""
+Python enumerations for use with Sublime API methods.
+"""
+
+
 import sublime
 
 from .vendor.python.enum import IntEnum, IntFlag
+from inspect import cleandoc
 
+
+def autodoc(prefix=None):
+    if prefix is None:
+        prefix_str = ''
+    else:
+        prefix_str = prefix + '_'
+
+    def decorator(enum):
+        enum.__doc__ = cleandoc(enum.__doc__) + '\n\n' + '\n'.join([
+            cleandoc("""
+            .. py:attribute:: {name}
+
+                = :attr:`sublime.{pre}{name}`
+            """).format(name=item.name, pre=prefix_str) for item in enum
+        ])
+
+        return enum
+
+    return decorator
+
+
+@autodoc('DIALOG')
 class DialogResult(IntEnum):
+    """
+    An :class:`~enum.IntEnum` for use with :func:`sublime.yes_no_cancel_dialog`.
+    """
     CANCEL = sublime.DIALOG_CANCEL
     YES = sublime.DIALOG_YES
     NO = sublime.DIALOG_NO
 
 
+@autodoc('CLASS')
 class PointClass(IntFlag):
+    """
+    An :class:`~enum.IntFlag` for use with several methods of :class:`sublime.View`:
+
+    - :meth:`~sublime.View.classify`
+    - :meth:`~sublime.View.find_by_class`
+    - :meth:`~sublime.View.expand_by_class`
+    """
     WORD_START = sublime.CLASS_WORD_START
     WORD_END = sublime.CLASS_WORD_END
     PUNCTUATION_START = sublime.CLASS_PUNCTUATION_START
@@ -20,12 +59,23 @@ class PointClass(IntFlag):
     EMPTY_LINE = sublime.CLASS_EMPTY_LINE
 
 
+@autodoc()
 class FindOption(IntFlag):
+    """
+    An :class:`~enum.IntFlag` for use with several methods of :class:`sublime.View`:
+
+    - :meth:`~sublime.View.find`
+    - :meth:`~sublime.View.find_all`
+    """
     LITERAL = sublime.LITERAL
     IGNORECASE = sublime.IGNORECASE
 
 
+@autodoc()
 class RegionOption(IntFlag):
+    """
+    An :class:`~enum.IntFlag` for use with :meth:`sublime.View.add_regions`.
+    """
     DRAW_EMPTY = sublime.DRAW_EMPTY
     HIDE_ON_MINIMAP = sublime.HIDE_ON_MINIMAP
     DRAW_EMPTY_AS_OVERWRITE = sublime.DRAW_EMPTY_AS_OVERWRITE
@@ -38,23 +88,39 @@ class RegionOption(IntFlag):
     HIDDEN = sublime.HIDDEN
 
 
+@autodoc()
 class PopupOption(IntFlag):
+    """
+    An :class:`~enum.IntFlag` for use with :meth:`sublime.View.show_popup`.
+    """
     COOPERATE_WITH_AUTO_COMPLETE = sublime.COOPERATE_WITH_AUTO_COMPLETE
     HIDE_ON_MOUSE_MOVE = sublime.HIDE_ON_MOUSE_MOVE
     HIDE_ON_MOUSE_MOVE_AWAY = sublime.HIDE_ON_MOUSE_MOVE_AWAY
 
 
+@autodoc('LAYOUT')
 class PhantomLayout(IntFlag):
+    """
+    An :class:`~enum.IntFlag` for use with :class:`sublime.Phantom`.
+    """
     INLINE = sublime.LAYOUT_INLINE
     BELOW = sublime.LAYOUT_BELOW
     BLOCK = sublime.LAYOUT_BLOCK
 
 
+@autodoc()
 class OpenFileOption(IntFlag):
+    """
+    An :class:`~enum.IntFlag` for use with :meth:`sublime.Window.open_file`.
+    """
     ENCODED_POSITION = sublime.ENCODED_POSITION
     TRANSIENT = sublime.TRANSIENT
 
 
+@autodoc()
 class QuickPanelOption(IntFlag):
+    """
+    An :class:`~enum.IntFlag` for use with :meth:`sublime.Window.show_quick_panel`.
+    """
     MONOSPACE_FONT = sublime.MONOSPACE_FONT
     KEEP_OPEN_ON_FOCUS_LOST = sublime.KEEP_OPEN_ON_FOCUS_LOST


### PR DESCRIPTION
The Sphinx mock module class interacts weirdly with enums, so I wrote a custom mock that provides arbitrary integers for properties that look like constants. With this done, I added a decorator that automatically adds a enum's members to its docstring.