### PR TITLE
 Construct NamedSettingsDict without explicit .sublime-settings extension.

### DIFF
--- a/st3/sublime_lib/settings_dict.py
+++ b/st3/sublime_lib/settings_dict.py
@@ -202,7 +202,11 @@ class NamedSettingsDict(SettingsDict):
     def __init__(self, name):
         """Return a new NamedSettingsDict corresponding to the given name."""
 
-        self.name = name
+        if name.endswith('.sublime-settings'):
+            self.name = name[:-17]
+        else:
+            self.name = name
+
         super().__init__(sublime.load_settings(self.file_name))
 
     def save(self):

--- a/st3/sublime_lib/settings_dict.py
+++ b/st3/sublime_lib/settings_dict.py
@@ -193,12 +193,18 @@ class NamedSettingsDict(SettingsDict):
     file.
     """
 
+    @property
+    def file_name(self):
+        """The name of the sublime-settings files associated with the
+        NamedSettingsDict."""
+        return self.name + '.sublime-settings'
+
     def __init__(self, name):
         """Return a new NamedSettingsDict corresponding to the given name."""
 
-        super().__init__(sublime.load_settings(name))
         self.name = name
+        super().__init__(sublime.load_settings(self.file_name))
 
     def save(self):
         """Flushes any in-memory changes to the named settings object to disk."""
-        sublime.save_settings(self.name)
+        sublime.save_settings(self.file_name)

--- a/tests/test_named_settings_dict.py
+++ b/tests/test_named_settings_dict.py
@@ -22,6 +22,8 @@ class TestNamedSettingsDict(DeferrableTestCase):
     def test_named(self):
         other = NamedSettingsDict(self.name)
 
+        self.fancy.pop("example_setting", None)
+        self.assertNotIn("example_setting", self.fancy)
         self.fancy["example_setting"] = "Hello, World!"
 
         self.assertIn("example_setting", self.fancy)
@@ -32,3 +34,11 @@ class TestNamedSettingsDict(DeferrableTestCase):
         yield
 
         self.assertTrue(path.exists(self.settings_path))
+
+    def test_file_extension(self):
+        other = NamedSettingsDict(self.name + '.sublime-settings')
+
+        self.fancy.pop("example_setting", None)
+        self.assertNotIn("example_setting", self.fancy)
+        self.fancy["example_setting"] = "Hello, World!"
+        self.assertEquals(other['example_setting'], 'Hello, World!')

--- a/tests/test_named_settings_dict.py
+++ b/tests/test_named_settings_dict.py
@@ -8,17 +8,16 @@ from unittesting import DeferrableTestCase
 
 
 class TestNamedSettingsDict(DeferrableTestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def setUp(self):
-        self.name = "_sublime_lib_NamedSettingsDictTest.sublime-settings"
-        self.settings_path = path.join(sublime.packages_path(), 'User', self.name)
+        self.name = "_sublime_lib_NamedSettingsDictTest"
         self.fancy = NamedSettingsDict(self.name)
+        self.settings_path = path.join(sublime.packages_path(), 'User', self.fancy.file_name)
 
     def tearDown(self):
-        if path.exists(self.settings_path):
+        try:
             os.remove(self.settings_path)
+        except FileNotFoundError:
+            pass
 
     def test_named(self):
         other = NamedSettingsDict(self.name)


### PR DESCRIPTION
Before:

```python
settings = NamedSettingsDict("Preferences.sublime-settings")
settings.name # "Preferences.sublime-settings"
```

After:

```python
settings = NamedSettingsDict("Preferences")
settings.name # "Preferences"
settings.file_name # "Preferences.sublime-settings"
```