### PR TITLE
Fixed indentation for print

### DIFF
--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -111,9 +111,11 @@ class ViewStream(TextIOBase):
         })
         return self.view.size() - old_size
 
-    def print(self, *objects, **kwargs):
-        """Shorthand for ``print(*objects, file=self, **kwargs)``."""
-        print(*objects, file=self, **kwargs)
+    def print(self, *objects, sep=' ', end='\n'):
+        """Print `objects` to the view, separated by `sep` and followed by `end`
+        (similar to the builtin :func:`print()` function). Converts arguments to
+        string using :func:`str()`."""
+        self.write(sep.join(map(str, objects)) + end)
 
     def flush(self):
         """Do nothing. (The stream is not buffered.)"""

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -127,11 +127,16 @@ class TestViewStream(TestCase):
         self.assertContents('')
 
     def _compare_print(self, *args, **kwargs):
+        s = StringIO()
+        print(*args, file=s, **kwargs)
+
         self.stream.clear()
         self.stream.print(*args, **kwargs)
 
-        s = StringIO()
-        print(*args, file=s, **kwargs)
+        self.assertContents(s.getvalue())
+
+        self.stream.clear()
+        print(*args, file=self.stream, **kwargs)
 
         self.assertContents(s.getvalue())
 

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -110,17 +110,21 @@ class TestViewStream(TestCase):
         self.assertEqual(text, "World")
         self.assertEqual(self.stream.tell(), 12)
 
-    def test_write_read_only(self):
+    def test_write_read_only_failure(self):
         self.stream.view.set_read_only(True)
 
         self.assertRaises(ValueError, self.stream.write, 'foo')
         self.assertRaises(ValueError, self.stream.clear)
 
+    def test_write_read_only_success(self):
+        self.stream.view.set_read_only(True)
         self.stream.force_writes = True
-        self.assertEqual(self.stream.write('foo'), 3)
+
+        self.stream.write('foo')
+        self.assertContents('foo')
 
         self.stream.clear()
-        self.assertEqual(self.stream.view.size(), 0)
+        self.assertContents('')
 
     def _compare_print(self, *args, **kwargs):
         self.stream.clear()
@@ -146,18 +150,21 @@ class TestViewStream(TestCase):
         self.stream.print(text)
         self.assertContents(text + "\n")
 
-    def test_print_read_only(self):
+    def test_print_read_only_failure(self):
         self.stream.view.set_read_only(True)
 
         self.assertRaises(ValueError, self.stream.print, 'foo')
         self.assertRaises(ValueError, self.stream.clear)
 
+    def test_print_read_only_success(self):
+        self.stream.view.set_read_only(True)
         self.stream.force_writes = True
+
         self.stream.print('foo')
         self.assertContents("foo\n")
 
         self.stream.clear()
-        self.assertEqual(self.stream.view.size(), 0)
+        self.assertContents('')
 
     def test_unsupported(self):
         self.assertRaises(UnsupportedOperation, self.stream.detach)

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -48,11 +48,12 @@ class TestViewStream(TestCase):
         self.assertEqual(size, self.stream.view.size())
 
     def test_no_indent(self):
-        text = "Hello\n    World\n!"
+        text = "    "
 
         self.stream.view.settings().set('auto_indent', True)
         self.stream.write(text)
-        self.assertContents(text)
+        self.stream.write("\n")
+        self.assertContents(text + "\n")
 
     def test_clear(self):
         self.stream.write("Some text")
@@ -124,7 +125,6 @@ class TestViewStream(TestCase):
     def _compare_print(self, *args, **kwargs):
         self.stream.clear()
         self.stream.print(*args, **kwargs)
-        self.stream.seek_start()
 
         s = StringIO()
         print(*args, file=s, **kwargs)
@@ -140,7 +140,7 @@ class TestViewStream(TestCase):
         self._compare_print(text, number, sep='', end='')
 
     def test_print_no_indent(self):
-        text = "Hello\n    World\n!"
+        text = "    "
 
         self.stream.view.settings().set('auto_indent', True)
         self.stream.print(text)


### PR DESCRIPTION
Apparently the `ViewStream.print` function wasn't handling indentation correctly. I feel like it should have worked, but it didn't. Now it does.

This PR just implements `print` directly rather than using the builtin. The docstring is probably more explicit like this anyway. As a side effect, it will raise `ArgumentError` if the user passes `file` or `flush` arguments.