### PR TITLE
NOT_GIVEN should not be a dict.

### DIFF
--- a/st3/sublime_lib/settings_dict.py
+++ b/st3/sublime_lib/settings_dict.py
@@ -22,7 +22,7 @@ def ismapping(obj):
     return isinstance(obj, Mapping)
 
 
-NOT_GIVEN = {}
+NOT_GIVEN = object()
 
 
 class SettingsDict():


### PR DESCRIPTION
Originally, I used `{}` for the unique value of `NOT_GIVEN` (for the `pop` method). My intent was to create a new, featureless object, but I must have had JavaScript on my mind. `{}` is a `dict`, not a plain `object`. This PR uses `object()` instead. I think that this is preferable because:

- It's the simplest possible object to use.
- It stands out as being "meaningfully meaningless".
- `{} == {}` but `object() != object()`, so it's a safer convention to use in general.

There should be no functional difference in this case because `pop` correctly used `is` instead of `==`.