### PR TITLE
Added new_window and close_window.

### DIFF
--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -2,5 +2,4 @@ from .settings_dict import SettingsDict  # noqa: F401
 from .settings_dict import NamedSettingsDict  # noqa: F401
 from .view_stream import ViewStream  # noqa: F401
 from .output_panel import OutputPanel  # noqa: F401
-from .window_utils import new_window  # noqa: F401
-from .window_utils import close_window  # noqa: F401
+from .window_utils import new_window, close_window  # noqa: F401

--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -2,3 +2,5 @@ from .settings_dict import SettingsDict  # noqa: F401
 from .settings_dict import NamedSettingsDict  # noqa: F401
 from .view_stream import ViewStream  # noqa: F401
 from .output_panel import OutputPanel  # noqa: F401
+from .window_utils import new_window  # noqa: F401
+from .window_utils import close_window  # noqa: F401

--- a/st3/sublime_lib/window_utils.py
+++ b/st3/sublime_lib/window_utils.py
@@ -1,0 +1,64 @@
+import sublime
+
+
+__all__ = ['new_window', 'close_window']
+
+
+def new_window(
+    *,
+    menu_visible=None,
+    sidebar_visible=None,
+    tabs_visible=None,
+    minimap_visible=None,
+    status_bar_visible=None,
+    project_data=None
+):
+    """Open a new window, returning the :class:`~sublime.Window` object.
+
+    :raises RuntimeError: if the window is not created for any reason.
+    """
+    original_ids = set(window.id() for window in sublime.windows())
+
+    sublime.run_command('new_window')
+
+    try:
+        window = next(window for window in sublime.windows() if window.id() not in original_ids)
+    except StopIteration:
+        raise RuntimeError("Window not created.")
+
+    if menu_visible is not None:
+        window.set_menu_visible(menu_visible)
+
+    if sidebar_visible is not None:
+        window.set_sidebar_visible(sidebar_visible)
+
+    if tabs_visible is not None:
+        window.set_tabs_visible(tabs_visible)
+
+    if minimap_visible is not None:
+        window.set_minimap_visible(minimap_visible)
+
+    if status_bar_visible is not None:
+        window.set_status_bar_visible(status_bar_visible)
+
+    if project_data is not None:
+        window.set_project_data(project_data)
+
+    return window
+
+
+def close_window(window, *, force=False):
+    """
+    Close the given window, discarding unsaved changes if `force` is ``True``.
+
+    :raise ValueError: if any view in the window has unsaved changes and `force`
+    is not ``True``.
+    """
+    for view in window.views():
+        if view.is_dirty() and not view.is_scratch():
+            if force:
+                view.set_scratch(True)
+            else:
+                raise ValueError('A view has unsaved changes.')
+
+    window.run_command('close_window')

--- a/st3/sublime_lib/window_utils.py
+++ b/st3/sublime_lib/window_utils.py
@@ -24,7 +24,7 @@ def new_window(
     try:
         window = next(window for window in sublime.windows() if window.id() not in original_ids)
     except StopIteration:
-        raise RuntimeError("Window not created.")
+        raise RuntimeError("Window not created.") from None
 
     if menu_visible is not None:
         window.set_menu_visible(menu_visible)

--- a/tests/test_window_utils.py
+++ b/tests/test_window_utils.py
@@ -1,0 +1,90 @@
+import sublime
+from unittesting import DeferrableTestCase
+
+from sublime_lib import new_window, close_window
+
+
+class TestNewWindow(DeferrableTestCase):
+
+    def tearDown(self):
+        if getattr(self, '_window', None):
+            close_window(self._window, force=True)
+
+    def test_is_valid(self):
+        self._window = new_window()
+        self.assertTrue(self._window.is_valid())
+
+    def test_has_view(self):
+        self._window = new_window()
+        self.assertIsNotNone(self._window.active_view())
+
+    def test_close_window(self):
+        self._window = new_window()
+        close_window(self._window)
+        yield 500
+        self.assertFalse(self._window.is_valid())
+
+    def test_close_unsaved(self):
+        self._window = new_window()
+
+        self._window.active_view().run_command('insert', {'characters': 'Hello, World!'})
+
+        with self.assertRaises(ValueError):
+            close_window(self._window)
+
+        close_window(self._window, force=True)
+        yield 500
+        self.assertFalse(self._window.is_valid())
+
+    def test_menu_visible(self):
+        self._window = new_window(menu_visible=True)
+        self.assertTrue(self._window.is_menu_visible())
+
+    def test_menu_not_visible(self):
+        self._window = new_window(menu_visible=False)
+        self.assertFalse(self._window.is_menu_visible())
+
+    def test_sidebar_visible(self):
+        self._window = new_window(sidebar_visible=True)
+        self.assertTrue(self._window.is_sidebar_visible())
+
+    def test_sidebar_not_visible(self):
+        self._window = new_window(sidebar_visible=False)
+        self.assertFalse(self._window.is_sidebar_visible())
+
+    def test_tabs_visible(self):
+        self._window = new_window(tabs_visible=True)
+        self.assertTrue(self._window.get_tabs_visible())
+
+    def test_tabs_not_visible(self):
+        self._window = new_window(tabs_visible=False)
+        self.assertFalse(self._window.get_tabs_visible())
+
+    def test_minimap_visible(self):
+        self._window = new_window(minimap_visible=True)
+        self.assertTrue(self._window.is_minimap_visible())
+
+    def test_minimap_not_visible(self):
+        self._window = new_window(minimap_visible=False)
+        self.assertFalse(self._window.is_minimap_visible())
+
+    def test_status_bar_visible(self):
+        self._window = new_window(status_bar_visible=True)
+        self.assertTrue(self._window.is_status_bar_visible())
+
+    def test_status_bar_not_visible(self):
+        self._window = new_window(status_bar_visible=False)
+        self.assertFalse(self._window.is_status_bar_visible())
+
+    def test_project_data(self):
+        data = {
+            'folders': [
+                {'path': sublime.packages_path()},
+            ],
+        }
+
+        self._window = new_window(project_data=data)
+        self.assertEqual(
+            self._window.project_data(),
+            data
+        )


### PR DESCRIPTION
By analogy to `view_utils`.

`new_window` creates a new Window and returns it. This is apparently not a core feature. I'm not sure what the failure modes are. deathaxe mentioned on Discord that the Window might not be created immediately if the command is invoked from a non-main thread. If so, then we might to define another function that either a) waits for the new window or b) takes a callback.

`new_window` also takes a pile of convenience arguments (nothing complicated).

`close_window`, like `close_view`, closes a Window without showing a dialog. If there are views with unsaved changes, it will discard changes if `force` is True or raise `ValueError` otherwise.