### PR TITLE
Added show_cursor to ViewStream.

### DIFF
--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -17,7 +17,7 @@ class OutputPanel(ViewStream):
         cls,
         window, name, *,
         force_writes=False,
-        auto_show_cursor=False,
+        follow_cursor=False,
         unlisted=False,
         **kwargs
     ):
@@ -33,18 +33,18 @@ class OutputPanel(ViewStream):
         view = window.create_output_panel(name, unlisted)
         set_view_options(view, **kwargs)
 
-        return cls(window, name, force_writes=force_writes, auto_show_cursor=auto_show_cursor)
+        return cls(window, name, force_writes=force_writes, follow_cursor=follow_cursor)
 
     def __init__(
         self, window, name, *,
         force_writes=False,
-        auto_show_cursor=False
+        follow_cursor=False
     ):
         view = window.find_output_panel(name)
         if view is None:
             raise ValueError('Output panel "%s" does not exist.' % name)
 
-        super().__init__(view, force_writes=force_writes, auto_show_cursor=auto_show_cursor)
+        super().__init__(view, force_writes=force_writes, follow_cursor=follow_cursor)
 
         self.window = window
         self.name = name

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -17,6 +17,7 @@ class OutputPanel(ViewStream):
         cls,
         window, name, *,
         force_writes=False,
+        auto_show_cursor=False,
         unlisted=False,
         **kwargs
     ):
@@ -32,17 +33,18 @@ class OutputPanel(ViewStream):
         view = window.create_output_panel(name, unlisted)
         set_view_options(view, **kwargs)
 
-        return cls(window, name, force_writes=force_writes)
+        return cls(window, name, force_writes=force_writes, auto_show_cursor=auto_show_cursor)
 
     def __init__(
         self, window, name, *,
-        force_writes=False
+        force_writes=False,
+        auto_show_cursor=False
     ):
         view = window.find_output_panel(name)
         if view is None:
             raise ValueError('Output panel "%s" does not exist.' % name)
 
-        super().__init__(view, force_writes=force_writes)
+        super().__init__(view, force_writes=force_writes, auto_show_cursor=auto_show_cursor)
 
         self.window = window
         self.name = name

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -134,7 +134,6 @@ class ViewStream(TextIOBase):
         """Shorthand for :func:`print()` passing this ViewStream as the `file`
         argument."""
         print(*objects, file=self, sep=sep, end=end)
-        self._maybe_show_cursor()
 
     def flush(self):
         """Do nothing. (The stream is not buffered.)"""

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -36,7 +36,7 @@ class ViewStream(TextIOBase):
     will write to the view even if it is read-only. Otherwise, those methods
     will raise :exc:`ValueError`.
 
-    :argument auto_show_cursor: If ``True``, then any method that moves the
+    :argument follow_cursor: If ``True``, then any method that moves the
     cursor position will scroll the view to ensure that the new position is
     visible.
     """
@@ -79,10 +79,10 @@ class ViewStream(TextIOBase):
         elif not self.view.sel()[0].empty():
             raise ValueError("The underlying view's selection is not empty.")
 
-    def __init__(self, view, *, force_writes=False, auto_show_cursor=False):
+    def __init__(self, view, *, force_writes=False, follow_cursor=False):
         self.view = view
         self.force_writes = force_writes
-        self.auto_show_cursor = auto_show_cursor
+        self.follow_cursor = follow_cursor
 
     @guard_validity
     @guard_selection
@@ -199,7 +199,7 @@ class ViewStream(TextIOBase):
         self.view.show(self._tell())
 
     def _maybe_show_cursor(self):
-        if self.auto_show_cursor:
+        if self.follow_cursor:
             self._show_cursor()
 
     @guard_validity

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -184,14 +184,6 @@ class TestViewStream(DeferrableTestCase):
         yield 200
         self.assertCursorVisible()
 
-        self.stream.seek_start(show_cursor=True)
-        yield 200
-        self.assertCursorVisible()
-
-        self.stream.seek_end(show_cursor=True)
-        yield 200
-        self.assertCursorVisible()
-
     def test_show_cursor_auto(self):
         self.stream.auto_show_cursor = True
 

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -185,7 +185,7 @@ class TestViewStream(DeferrableTestCase):
         self.assertCursorVisible()
 
     def test_show_cursor_auto(self):
-        self.stream.auto_show_cursor = True
+        self.stream.follow_cursor = True
 
         self.stream.write('test\n' * 200)
         yield 200


### PR DESCRIPTION
Allows you to implicitly or explicitly scroll to show the cursor.

In hindsight, I'm not sure whether the explicit `show_cursor` arguments are necessary. If the user wants to show the cursor after calling `write` or somesuch, they can call `show_cursor()`. I'll probably remove those.