### PR TITLE
Improve `seek()`

### DIFF
--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -141,24 +141,18 @@ class ViewStream(TextIOBase):
 
     @guard_validity
     def seek(self, offset, whence=SEEK_SET):
-        """Move the cursor in the view to the given offset. If `whence` is
-        provided, the behavior is the same as for TextIOBase. If the view had
+        """Move the cursor in the view and return the new offset. If `whence` is
+        provided, the behavior is the same as for :class:`IOBase`. If the cursor
+        would move before the beginning of the view, it will move to the
+        beginning instead, and likewise for the end of the view. If the view had
         multiple selections, none will be preserved.
         """
         if whence == SEEK_SET:
             return self._seek(offset)
         elif whence == SEEK_CUR:
-            if offset != 0:
-                raise TypeError('Argument "offset" must be zero when "whence" '
-                                'is io.SEEK_CUR.')
-            # Don't move.
-            self._maybe_show_cursor()
-            return self._tell()
+            return self._seek(self._tell() + offset)
         elif whence == SEEK_END:
-            if offset != 0:
-                raise TypeError('Argument "offset" must be zero when "whence" '
-                                'is io.SEEK_END.')
-            return self._seek(self.view.size())
+            return self._seek(self.view.size() + offset)
         else:
             raise TypeError('Invalid value for argument "whence".')
 
@@ -167,7 +161,7 @@ class ViewStream(TextIOBase):
         selection.clear()
         selection.add(Region(offset))
         self._maybe_show_cursor()
-        return offset
+        return self._tell()
 
     @guard_validity
     def seek_start(self):

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -169,6 +169,27 @@ class TestViewStream(DeferrableTestCase):
 
         self.stream.clear()
         self.assertContents('')
+    
+    def assertSeek(self, expected, *args):
+        returned = self.stream.seek(*args)
+        measured = self.stream.tell()
+        self.assertEqual(returned, expected)
+        self.assertEqual(measured, expected)
+
+    def test_seek(self):
+        from io import SEEK_SET, SEEK_CUR, SEEK_END
+
+        self.stream.write('test\n'*10)
+
+        self.assertSeek(0, -100)
+        self.assertSeek(50, 100)
+        self.assertSeek(25, 25, SEEK_SET)
+        self.assertSeek(35, 10, SEEK_CUR)
+        self.assertSeek(0, -100, SEEK_CUR)
+        self.assertSeek(50, 0, SEEK_END)
+        self.assertSeek(50, 100, SEEK_END)
+        self.assertSeek(40, -10, SEEK_END)
+        self.assertSeek(0, -100, SEEK_END)
 
     def assertCursorVisible(self):
         self.assertTrue(


### PR DESCRIPTION
Improved `seek()` to take any integer offset for any value of whence.

Also correctly return the new offset, even if it's different from the one that was passed in.