### PR TITLE
Improve __init__.py.

### DIFF
--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -1,7 +1,8 @@
-from .settings_dict import SettingsDict  # noqa: F401
-from .settings_dict import NamedSettingsDict  # noqa: F401
-from .view_stream import ViewStream  # noqa: F401
 from .output_panel import OutputPanel  # noqa: F401
-from .show_selection_panel import show_selection_panel  # noqa: F401
-from .window_utils import new_window, close_window  # noqa: F401
 from .resource_path import ResourcePath  # noqa: F401
+from .show_selection_panel import show_selection_panel  # noqa: F401
+from .settings_dict import SettingsDict, NamedSettingsDict  # noqa: F401
+from .syntax import list_syntaxes, get_syntax_for_scope  # noqa: F401
+from .view_stream import ViewStream  # noqa: F401
+from .view_utils import new_view, close_view  # noqa: F401
+from .window_utils import new_window, close_window  # noqa: F401

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -1,5 +1,5 @@
-from sublime_lib.syntax import list_syntaxes
-from sublime_lib.syntax import get_syntax_for_scope
+from sublime_lib import list_syntaxes
+from sublime_lib import get_syntax_for_scope
 from sublime_lib.syntax import get_yaml_metadata
 from sublime_lib.syntax import get_xml_metadata
 from sublime_lib.syntax import SyntaxInfo

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -1,5 +1,5 @@
 import sublime
-from sublime_lib.view_utils import new_view, close_view
+from sublime_lib import new_view, close_view
 
 from unittest import TestCase
 


### PR DESCRIPTION
- Alphabetize submodules.
- Import public functions from `syntax` and `view_utils`.
- Modify tests to import from `sublime_lib` when possible.

The contents of `flags` and `encoding` are still not exported directly by `sublime_lib`. For `flags`, this probably makes sense. For `encoding`, we'd probably have to export the functions with different names. I am okay with punting on that for now.