### PR TITLE
Improve coverage.

### DIFF
--- a/st3/sublime_lib/window_utils.py
+++ b/st3/sublime_lib/window_utils.py
@@ -44,7 +44,7 @@ def new_window(
 
     try:
         window = next(window for window in sublime.windows() if window.id() not in original_ids)
-    except StopIteration:
+    except StopIteration:  # pragma: no cover
         raise RuntimeError("Window not created.") from None
 
     if menu_visible is not None:

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -191,6 +191,10 @@ class TestViewStream(DeferrableTestCase):
         self.assertSeek(40, -10, SEEK_END)
         self.assertSeek(0, -100, SEEK_END)
 
+    def test_seek_invalid(self):
+        with self.assertRaises(TypeError):
+            self.stream.seek(0, -99)
+
     def assertCursorVisible(self):
         self.assertTrue(
             self.stream.view.visible_region().contains(

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -63,6 +63,15 @@ class TestViewUtils(TestCase):
 
         self.assertTrue(self.view.scope_name(0).startswith('source.js'))
 
+    def test_syntax(self):
+        path = 'Packages/JavaScript/JavaScript.sublime-syntax'
+        self.view = new_view(self.window, syntax=path)
+
+        self.assertEquals(
+            self.view.settings().get('syntax'),
+            path
+        )
+
     def test_unknown_args(self):
         self.assertRaises(
             ValueError,


### PR DESCRIPTION
The uncovered statements are mostly utility functions that should be moved into `_utils` and tested separately.

I don't know if there's a reasonable way to test the failure in `window_utils.new_window`.