### PR TITLE
Reformat docs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MODULEDIR     = st3
 .PHONY: source clean
 
 source:
-	SPHINX_APIDOC_OPTIONS=members,no-special-members sphinx-apidoc --separate --force --no-toc -o "$(SOURCEDIR)/modules" "$(MODULEDIR)"
+	SPHINX_APIDOC_OPTIONS=members sphinx-apidoc --force --module-first -o "$(SOURCEDIR)/modules" "$(MODULEDIR)"
 
 html:
 	sphinx-build -M html "$(SOURCEDIR)" "$(BUILDDIR)"

--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -1,27 +1,62 @@
-code, dt {
-    font-size: inherit !important;
+.related { display: none; }
+
+html {
+    font: 20px Roboto;
+    margin: 0;
 }
 
-ul.simple {
-    /*columns: 10em;*/
+body {
+    margin: 0 auto;
+    max-width: 33rem;
+
+    font-size: 15px;
+    line-height: 1rem;
 }
 
-ul.simple > li > :last-child {
-    margin-bottom: 0 !important;
+code, pre {
+    font-family: "Roboto Mono";
 }
 
-a > code {
-    color: inherit !important;
+h2 {
+    margin-top: 2rem;
+    border-bottom: 2px solid #aaa;
+    background-color: white;
+    font-weight: normal;
+    font-size: 1.5rem;
+    line-height: 2rem;
 }
 
-a:hover > code {
-    text-decoration: underline !important;
+#contents > div.container > ul {
+    list-style: none;
+    padding-left: 0;
+}
+
+#contents > div.container p {
+    margin-bottom: 0;
+}
+
+dl.class {
+    margin: 1rem 0;
+}
+
+li > p:only-child {
+    margin: 0;
+}
+
+p code {
+    background-color: #e7e7e7;
+}
+
+a:not(:hover) {
+    text-decoration: none;
 }
 
 pre {
-    font-size: inherit !important;
+    border: 1px solid #33333333;
+    border-radius: 2px;
+    padding: 0.25rem;
 }
 
-.descclassname {
-    font-weight: normal !important;
+div.footer {
+    border-top: 2px solid #aaa;
 }

--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -1,7 +1,10 @@
+@import url('https://fonts.googleapis.com/css?family=Lato:400,400i,700,700i|Roboto+Mono:400,400i,700,700i&subset=latin-ext');
+
 .related { display: none; }
 
 html {
-    font: 20px Roboto;
+    font-size: 20px;
+    font-family: "Lato","proxima-nova","Helvetica Neue",Arial,sans-serif;
     margin: 0;
 }
 
@@ -14,7 +17,7 @@ body {
 }
 
 code, pre {
-    font-family: "Roboto Mono";
+    font-family: "Roboto Mono",SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
 }
 
 h2 {

--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -57,7 +57,7 @@ dl.class > dt, dl.function > dt, dl.method > dt, dl.classmethod > dt, dl.attribu
 }
 
 h2 {
-    margin-top: 2rem;
+    margin-top: 1rem;
     border-bottom: 2px solid #aaa;
     background-color: white;
     font-weight: normal;
@@ -122,5 +122,6 @@ pre {
 }
 
 div.footer {
+    text-align: center;
     border-top: 2px solid #aaa;
 }

--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -2,6 +2,10 @@
 
 .related { display: none; }
 
+*:not(:hover) > a.headerlink {
+    display: none;
+}
+
 html {
     font-size: 20px;
     font-family: "Lato","proxima-nova","Helvetica Neue",Arial,sans-serif;
@@ -12,11 +16,11 @@ body {
     margin: 0 auto;
     max-width: 33rem;
 
-    font-size: 15px;
+    font-size: 14px;
     line-height: 1rem;
 }
 
-code, pre {
+code, pre, dl.class > dt, dl.function > dt, dl.method > dt, dl.classmethod > dt {
     font-family: "Roboto Mono",SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
 }
 
@@ -29,29 +33,64 @@ h2 {
     line-height: 2rem;
 }
 
-#contents > div.container > ul {
-    list-style: none;
-    padding-left: 0;
-}
-
 #contents > div.container p {
     margin-bottom: 0;
 }
 
-dl.class {
+#contents > div.container ul {
+    margin-top: 0;
+}
+
+ul, ol {
+    padding-left: 1rem;
+}
+
+dd {
+    margin-left: 1rem;
+}
+
+dd > :first-child {
+    margin-top: 0.25rem;
+}
+
+dd > ul, dd > ol {
+    padding-left: 0;
+}
+
+code.descname {
+    font-weight: bold;
+    font-size: 1.2em;
+}
+
+dl {
     margin: 1rem 0;
+}
+
+dl.classmethod > dt > em.property {
+    display: block;
+}
+
+dl.classmethod > dt > em.property::before {
+    content: '@';
+    display: inline;
 }
 
 li > p:only-child {
     margin: 0;
 }
 
-p code {
+code.literal:not(.xref) {
+    display: inline-block;
     background-color: #e7e7e7;
+    padding: 0 0.1rem;
 }
 
 a:not(:hover) {
     text-decoration: none;
+}
+
+a.reference {
+    font-weight: bold;
 }
 
 pre {

--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -14,13 +14,41 @@ html {
 
 body {
     margin: 0 auto;
-    max-width: 33rem;
 
     font-size: 14px;
     line-height: 1rem;
 }
 
-code, pre, dl.class > dt, dl.function > dt, dl.method > dt, dl.classmethod > dt {
+.document {
+    display: flex;
+    justify-content: center;
+    /*max-height: 100vh;*/
+}
+
+.document > * {
+    /*overflow: auto;*/
+    margin: 1rem;
+}
+
+.sphinxsidebar {
+    order: 0;
+    width: 10rem;
+}
+
+.sphinxsidebarwrapper {
+    position: fixed;
+}
+
+.documentwrapper  {
+    order: 1;
+    width: 33rem;
+}
+
+.clearer  { display: none; }
+
+code, pre,
+dl.class > dt, dl.function > dt, dl.method > dt, dl.classmethod > dt, dl.attribute > dt
+{
     font-family: "Roboto Mono",SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",Courier,monospace;
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,9 +44,11 @@ extensions = [
     'sphinx.ext.intersphinx',
 ]
 
-autodoc_mock_imports = ["sublime_plugin"]
-autodoc_default_flags = ["members"]
 autodoc_member_order = 'bysource'
+autodoc_default_options = {
+    'members': None,
+    'mock_imports': ['sublime_plugin']
+}
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
@@ -83,16 +85,13 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'basic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
 html_theme_options = {
-    # 'style_external_links': True,
-    # 'navigation_depth': 1,
-    'collapse_navigation': False,
 }
 
 html_experimental_html5_writer = True
@@ -111,6 +110,12 @@ html_static_path = ['_static']
 # 'searchbox.html']``.
 #
 # html_sidebars = {}
+
+html_sidebars = {'**': []}
+
+html_use_index = False
+html_use_smartypants = False
+html_compact_lists = True
 
 
 def setup(app):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,9 +77,7 @@ language = None
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-# pygments_style = 'sphinx'
-# pygments_style = 'default'
-pygments_style = 'github'
+pygments_style = 'sphinx'
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,7 +77,9 @@ language = None
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+# pygments_style = 'sphinx'
+# pygments_style = 'default'
+pygments_style = 'github'
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -111,7 +113,9 @@ html_static_path = ['_static']
 #
 # html_sidebars = {}
 
-html_sidebars = {'**': []}
+html_sidebars = {'**': [
+    "localtoc.html"
+]}
 
 html_use_index = False
 html_use_smartypants = False
@@ -119,9 +123,12 @@ html_compact_lists = True
 
 
 def setup(app):
+    from better_toctree import TocTreeCollector
+    app.add_env_collector(TocTreeCollector)
+
     app.add_stylesheet('style.css')
 
     from prettify_special_methods import PrettifySpecialMethods, show_special_methods
-
     app.add_transform(PrettifySpecialMethods)
+
     app.connect('autodoc-skip-member', show_special_methods)

--- a/docs/source/extensions/better_toctree.py
+++ b/docs/source/extensions/better_toctree.py
@@ -1,0 +1,324 @@
+# -*- coding: utf-8 -*-
+"""
+    sphinx.environment.collectors.toctree
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Toctree collector for sphinx.environment.
+
+    :copyright: Copyright 2007-2018 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from typing import cast
+
+from docutils import nodes
+
+from sphinx import addnodes
+from sphinx.environment.adapters.toctree import TocTree
+from sphinx.environment.collectors import EnvironmentCollector
+from sphinx.locale import __
+from sphinx.transforms import SphinxContentsFilter
+from sphinx.util import url_re, logging
+
+if False:
+    # For type annotation
+    from typing import Any, Dict, List, Set, Tuple, Type, TypeVar  # NOQA
+    from sphinx.application import Sphinx  # NOQA
+    from sphinx.builders import Builder  # NOQA
+    from sphinx.environment import BuildEnvironment  # NOQA
+    from sphinx.util.typing import unicode  # NOQA
+
+    N = TypeVar('N')
+
+logger = logging.getLogger(__name__)
+
+
+class TocTreeCollector(EnvironmentCollector):
+    def clear_doc(self, app, env, docname):
+        # type: (Sphinx, BuildEnvironment, unicode) -> None
+        env.tocs.pop(docname, None)
+        env.toc_secnumbers.pop(docname, None)
+        env.toc_fignumbers.pop(docname, None)
+        env.toc_num_entries.pop(docname, None)
+        env.toctree_includes.pop(docname, None)
+        env.glob_toctrees.discard(docname)
+        env.numbered_toctrees.discard(docname)
+
+        for subfn, fnset in list(env.files_to_rebuild.items()):
+            fnset.discard(docname)
+            if not fnset:
+                del env.files_to_rebuild[subfn]
+
+    def merge_other(self, app, env, docnames, other):
+        # type: (Sphinx, BuildEnvironment, Set[unicode], BuildEnvironment) -> None
+        for docname in docnames:
+            env.tocs[docname] = other.tocs[docname]
+            env.toc_num_entries[docname] = other.toc_num_entries[docname]
+            if docname in other.toctree_includes:
+                env.toctree_includes[docname] = other.toctree_includes[docname]
+            if docname in other.glob_toctrees:
+                env.glob_toctrees.add(docname)
+            if docname in other.numbered_toctrees:
+                env.numbered_toctrees.add(docname)
+
+        for subfn, fnset in other.files_to_rebuild.items():
+            env.files_to_rebuild.setdefault(subfn, set()).update(fnset & set(docnames))
+
+    def process_doc(self, app, doctree):
+        # type: (Sphinx, nodes.document) -> None
+        """Build a TOC from the doctree and store it in the inventory."""
+        docname = app.env.docname
+        numentries = [0]  # nonlocal again...
+
+        def traverse_in_section(node, cls):
+            # type: (nodes.Element, Type[N]) -> List[N]
+            """Like traverse(), but stay within the same section."""
+            result = []  # type: List[N]
+            if isinstance(node, cls):
+                result.append(node)
+            for child in node.children:
+                if isinstance(child, nodes.section):
+                    continue
+                elif isinstance(child, nodes.Element):
+                    result.extend(traverse_in_section(child, cls))
+            return result
+
+        def build_toc(node, depth=1):
+            # type: (nodes.Element, int) -> nodes.bullet_list
+            entries = []  # type: List[nodes.Element]
+            for sectionnode in node:
+                # find all toctree nodes in this section and add them
+                # to the toc (just copying the toctree node which is then
+                # resolved in self.get_and_resolve_doctree)
+                if isinstance(sectionnode, nodes.section):
+                    title = sectionnode[0]
+                    # copy the contents of the section title, but without references
+                    # and unnecessary stuff
+                    visitor = SphinxContentsFilter(doctree)
+                    title.walkabout(visitor)
+                    nodetext = visitor.get_entry_text()
+                    if not numentries[0]:
+                        # for the very first toc entry, don't add an anchor
+                        # as it is the file's title anyway
+                        anchorname = ''
+                    else:
+                        anchorname = '#' + sectionnode['ids'][0]
+                    numentries[0] += 1
+                    # make these nodes:
+                    # list_item -> compact_paragraph -> reference
+                    reference = nodes.reference(
+                        '', '', internal=True, refuri=docname,
+                        anchorname=anchorname, *nodetext)
+                    para = addnodes.compact_paragraph('', '', reference)
+                    item = nodes.list_item('', para)  # type: nodes.Element
+                    sub_item = build_toc(sectionnode, depth + 1)
+                    if sub_item:
+                        item += sub_item
+                    entries.append(item)
+                elif isinstance(sectionnode, addnodes.only):
+                    onlynode = addnodes.only(expr=sectionnode['expr'])
+                    blist = build_toc(sectionnode, depth)
+                    if blist:
+                        onlynode += blist.children
+                        entries.append(onlynode)
+                # ADDED
+                elif isinstance(sectionnode, addnodes.desc):
+                    target = sectionnode.traverse(addnodes.desc_signature)[0]
+
+                    reference = nodes.reference(
+                        '', '',
+                        nodes.Text(target.attributes['fullname']),
+                        internal=True,
+                        refuri=docname,
+                        anchorname='#' + target.attributes['ids'][0],
+                    )
+
+                    entries.append(
+                        nodes.list_item(
+                            '',
+                            addnodes.compact_paragraph('', '', reference)
+                        )
+                    )
+                # /ADDED
+                elif isinstance(sectionnode, nodes.Element):
+                    for toctreenode in traverse_in_section(sectionnode,
+                                                           addnodes.toctree):
+                        item = toctreenode.copy()
+                        entries.append(item)
+                        # important: do the inventory stuff
+                        TocTree(app.env).note(docname, toctreenode)
+            if entries:
+                return nodes.bullet_list('', *entries)
+            return None
+        toc = build_toc(doctree)
+        if toc:
+            app.env.tocs[docname] = toc
+        else:
+            app.env.tocs[docname] = nodes.bullet_list('')
+        app.env.toc_num_entries[docname] = numentries[0]
+
+    def get_updated_docs(self, app, env):
+        # type: (Sphinx, BuildEnvironment) -> List[unicode]
+        return self.assign_section_numbers(env) + self.assign_figure_numbers(env)
+
+    def assign_section_numbers(self, env):
+        # type: (BuildEnvironment) -> List[unicode]
+        """Assign a section number to each heading under a numbered toctree."""
+        # a list of all docnames whose section numbers changed
+        rewrite_needed = []
+
+        assigned = set()  # type: Set[unicode]
+        old_secnumbers = env.toc_secnumbers
+        env.toc_secnumbers = {}
+
+        def _walk_toc(node, secnums, depth, titlenode=None):
+            # type: (nodes.Element, Dict, int, nodes.title) -> None
+            # titlenode is the title of the document, it will get assigned a
+            # secnumber too, so that it shows up in next/prev/parent rellinks
+            for subnode in node.children:
+                if isinstance(subnode, nodes.bullet_list):
+                    numstack.append(0)
+                    _walk_toc(subnode, secnums, depth - 1, titlenode)
+                    numstack.pop()
+                    titlenode = None
+                elif isinstance(subnode, nodes.list_item):
+                    _walk_toc(subnode, secnums, depth, titlenode)
+                    titlenode = None
+                elif isinstance(subnode, addnodes.only):
+                    # at this stage we don't know yet which sections are going
+                    # to be included; just include all of them, even if it leads
+                    # to gaps in the numbering
+                    _walk_toc(subnode, secnums, depth, titlenode)
+                    titlenode = None
+                elif isinstance(subnode, addnodes.compact_paragraph):
+                    numstack[-1] += 1
+                    reference = cast(nodes.reference, subnode[0])
+                    if depth > 0:
+                        number = list(numstack)
+                        secnums[reference['anchorname']] = tuple(numstack)
+                    else:
+                        number = None
+                        secnums[reference['anchorname']] = None
+                    reference['secnumber'] = number
+                    if titlenode:
+                        titlenode['secnumber'] = number
+                        titlenode = None
+                elif isinstance(subnode, addnodes.toctree):
+                    _walk_toctree(subnode, depth)
+
+        def _walk_toctree(toctreenode, depth):
+            # type: (addnodes.toctree, int) -> None
+            if depth == 0:
+                return
+            for (title, ref) in toctreenode['entries']:
+                if url_re.match(ref) or ref == 'self':
+                    # don't mess with those
+                    continue
+                elif ref in assigned:
+                    logger.warning(__('%s is already assigned section numbers '
+                                      '(nested numbered toctree?)'), ref,
+                                   location=toctreenode, type='toc', subtype='secnum')
+                elif ref in env.tocs:
+                    secnums = {}  # type: Dict[unicode, Tuple[int, ...]]
+                    env.toc_secnumbers[ref] = secnums
+                    assigned.add(ref)
+                    _walk_toc(env.tocs[ref], secnums, depth, env.titles.get(ref))
+                    if secnums != old_secnumbers.get(ref):
+                        rewrite_needed.append(ref)
+
+        for docname in env.numbered_toctrees:
+            assigned.add(docname)
+            doctree = env.get_doctree(docname)
+            for toctreenode in doctree.traverse(addnodes.toctree):
+                depth = toctreenode.get('numbered', 0)
+                if depth:
+                    # every numbered toctree gets new numbering
+                    numstack = [0]
+                    _walk_toctree(toctreenode, depth)
+
+        return rewrite_needed
+
+    def assign_figure_numbers(self, env):
+        # type: (BuildEnvironment) -> List[unicode]
+        """Assign a figure number to each figure under a numbered toctree."""
+
+        rewrite_needed = []
+
+        assigned = set()  # type: Set[unicode]
+        old_fignumbers = env.toc_fignumbers
+        env.toc_fignumbers = {}
+        fignum_counter = {}  # type: Dict[unicode, Dict[Tuple[int, ...], int]]
+
+        def get_figtype(node):
+            # type: (nodes.Node) -> unicode
+            for domain in env.domains.values():
+                figtype = domain.get_enumerable_node_type(node)
+                if figtype:
+                    return figtype
+
+            return None
+
+        def get_section_number(docname, section):
+            # type: (unicode, nodes.section) -> Tuple[int, ...]
+            anchorname = '#' + section['ids'][0]
+            secnumbers = env.toc_secnumbers.get(docname, {})
+            if anchorname in secnumbers:
+                secnum = secnumbers.get(anchorname)
+            else:
+                secnum = secnumbers.get('')
+
+            return secnum or tuple()
+
+        def get_next_fignumber(figtype, secnum):
+            # type: (unicode, Tuple[int, ...]) -> Tuple[int, ...]
+            counter = fignum_counter.setdefault(figtype, {})
+
+            secnum = secnum[:env.config.numfig_secnum_depth]
+            counter[secnum] = counter.get(secnum, 0) + 1
+            return secnum + (counter[secnum],)
+
+        def register_fignumber(docname, secnum, figtype, fignode):
+            # type: (unicode, Tuple[int, ...], unicode, nodes.Element) -> None
+            env.toc_fignumbers.setdefault(docname, {})
+            fignumbers = env.toc_fignumbers[docname].setdefault(figtype, {})
+            figure_id = fignode['ids'][0]
+
+            fignumbers[figure_id] = get_next_fignumber(figtype, secnum)
+
+        def _walk_doctree(docname, doctree, secnum):
+            # type: (unicode, nodes.Element, Tuple[int, ...]) -> None
+            for subnode in doctree.children:
+                if isinstance(subnode, nodes.section):
+                    next_secnum = get_section_number(docname, subnode)
+                    if next_secnum:
+                        _walk_doctree(docname, subnode, next_secnum)
+                    else:
+                        _walk_doctree(docname, subnode, secnum)
+                elif isinstance(subnode, addnodes.toctree):
+                    for title, subdocname in subnode['entries']:
+                        if url_re.match(subdocname) or subdocname == 'self':
+                            # don't mess with those
+                            continue
+
+                        _walk_doc(subdocname, secnum)
+                elif isinstance(subnode, nodes.Element):
+                    figtype = get_figtype(subnode)
+                    if figtype and subnode['ids']:
+                        register_fignumber(docname, secnum, figtype, subnode)
+
+                    _walk_doctree(docname, subnode, secnum)
+
+        def _walk_doc(docname, secnum):
+            # type: (unicode, Tuple[int, ...]) -> None
+            if docname not in assigned:
+                assigned.add(docname)
+                doctree = env.get_doctree(docname)
+                _walk_doctree(docname, doctree, secnum)
+
+        if env.config.numfig:
+            _walk_doc(env.config.master_doc, tuple())
+            for docname, fignums in env.toc_fignumbers.items():
+                if fignums != old_fignumbers.get(docname):
+                    rewrite_needed.append(docname)
+
+        return rewrite_needed

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,9 @@
-:mod:`sublime_lib` API
-======================
+:mod:`sublime_lib` API Reference
+================================
+
+A utility library for Sublime Text providing a variety of convenience features for other packages to use.
+
+For general documentation, see the `README <https://github.com/SublimeText/sublime_lib>`_.
 
 Settings dictionaries
 ---------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,44 +6,44 @@ Contents
 
 .. container:: table-of-contents
 
-  * `Settings dictionaries <#settings-dictionaries>`__
+  `Settings dictionaries <#settings-dictionaries>`__
 
-    * :class:`~sublime_lib.SettingsDict`
-    * :class:`~sublime_lib.NamedSettingsDict`
+  * :class:`~sublime_lib.SettingsDict`
+  * :class:`~sublime_lib.NamedSettingsDict`
 
-  * `Output streams <#output-streams>`__
+  `Output streams <#output-streams>`__
 
-    * :class:`~sublime_lib.ViewStream`
-    * :class:`~sublime_lib.OutputPanel`
+  * :class:`~sublime_lib.ViewStream`
+  * :class:`~sublime_lib.OutputPanel`
 
-  * `Resource paths <#resource-paths>`__
+  `Resource paths <#resource-paths>`__
 
-    * :class:`~sublime_lib.ResourcePath`
+  * :class:`~sublime_lib.ResourcePath`
 
-  * `View utilities <#view-utilities>`__
+  `View utilities <#view-utilities>`__
 
-    * :func:`~sublime_lib.new_view`
-    * :func:`~sublime_lib.close_view`
+  * :func:`~sublime_lib.new_view`
+  * :func:`~sublime_lib.close_view`
 
-  * `Window utilities <#window-utilities>`__
+  `Window utilities <#window-utilities>`__
 
-    * :func:`~sublime_lib.new_window`
-    * :func:`~sublime_lib.close_window`
-    * :func:`~sublime_lib.show_selection_panel`
+  * :func:`~sublime_lib.new_window`
+  * :func:`~sublime_lib.close_window`
+  * :func:`~sublime_lib.show_selection_panel`
 
-  * `Syntax utilities <#syntax-utilities>`__
+  `Syntax utilities <#syntax-utilities>`__
 
-    * :func:`~sublime_lib.list_syntaxes`
-    * :func:`~sublime_lib.get_syntax_for_scope`
+  * :func:`~sublime_lib.list_syntaxes`
+  * :func:`~sublime_lib.get_syntax_for_scope`
 
-  * :mod:`~sublime_lib.encodings` submodule
+  :mod:`~sublime_lib.encodings` submodule
 
-    * :func:`~sublime_lib.encodings.from_sublime`
-    * :func:`~sublime_lib.encodings.to_sublime`
+  * :func:`~sublime_lib.encodings.from_sublime`
+  * :func:`~sublime_lib.encodings.to_sublime`
 
-  * :mod:`~sublime_lib.flags` submodule
+  :mod:`~sublime_lib.flags` submodule
 
-    * :mod:`~sublime_lib.flags`
+  * :mod:`~sublime_lib.flags`
 
 Settings dictionaries
 ---------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,92 @@
-Welcome to sublime_lib's documentation!
-=======================================
+:mod:`sublime_lib` API
+======================
 
-.. toctree::
-   :glob:
+Contents
+--------
 
-   modules/sublime_lib.*
+.. container:: table-of-contents
+
+  * `Settings dictionaries <#settings-dictionaries>`__
+
+    * :class:`~sublime_lib.SettingsDict`
+    * :class:`~sublime_lib.NamedSettingsDict`
+
+  * `Output streams <#output-streams>`__
+
+    * :class:`~sublime_lib.ViewStream`
+    * :class:`~sublime_lib.OutputPanel`
+
+  * `Resource paths <#resource-paths>`__
+
+    * :class:`~sublime_lib.ResourcePath`
+
+  * `View utilities <#view-utilities>`__
+
+    * :func:`~sublime_lib.new_view`
+    * :func:`~sublime_lib.close_view`
+
+  * `Window utilities <#window-utilities>`__
+
+    * :func:`~sublime_lib.new_window`
+    * :func:`~sublime_lib.close_window`
+    * :func:`~sublime_lib.show_selection_panel`
+
+  * `Syntax utilities <#syntax-utilities>`__
+
+    * :func:`~sublime_lib.list_syntaxes`
+    * :func:`~sublime_lib.get_syntax_for_scope`
+
+  * :mod:`~sublime_lib.encodings` submodule
+
+    * :func:`~sublime_lib.encodings.from_sublime`
+    * :func:`~sublime_lib.encodings.to_sublime`
+
+  * :mod:`~sublime_lib.flags` submodule
+
+    * :mod:`~sublime_lib.flags`
+
+Settings dictionaries
+---------------------
+
+.. autoclass:: sublime_lib.SettingsDict
+.. autoclass:: sublime_lib.NamedSettingsDict
+
+Output streams
+--------------
+
+.. autoclass:: sublime_lib.ViewStream
+.. autoclass:: sublime_lib.OutputPanel
+
+Resource paths
+--------------
+
+.. autoclass:: sublime_lib.ResourcePath
+
+View utilities
+--------------
+
+.. autofunction:: sublime_lib.new_view
+.. autofunction:: sublime_lib.close_view
+
+Window utilities
+----------------
+
+.. autofunction:: sublime_lib.new_window
+.. autofunction:: sublime_lib.close_window
+.. autofunction:: sublime_lib.show_selection_panel
+
+Syntax utilities
+----------------
+
+.. autofunction:: sublime_lib.list_syntaxes
+.. autofunction:: sublime_lib.get_syntax_for_scope
+
+:mod:`~sublime_lib.encodings` submodule
+---------------------------------------
+
+.. automodule:: sublime_lib.encodings
+
+:mod:`~sublime_lib.flags` submodule
+-----------------------------------
+
+.. automodule:: sublime_lib.flags

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,50 +1,6 @@
 :mod:`sublime_lib` API
 ======================
 
-Contents
---------
-
-.. container:: table-of-contents
-
-  `Settings dictionaries <#settings-dictionaries>`__
-
-  * :class:`~sublime_lib.SettingsDict`
-  * :class:`~sublime_lib.NamedSettingsDict`
-
-  `Output streams <#output-streams>`__
-
-  * :class:`~sublime_lib.ViewStream`
-  * :class:`~sublime_lib.OutputPanel`
-
-  `Resource paths <#resource-paths>`__
-
-  * :class:`~sublime_lib.ResourcePath`
-
-  `View utilities <#view-utilities>`__
-
-  * :func:`~sublime_lib.new_view`
-  * :func:`~sublime_lib.close_view`
-
-  `Window utilities <#window-utilities>`__
-
-  * :func:`~sublime_lib.new_window`
-  * :func:`~sublime_lib.close_window`
-  * :func:`~sublime_lib.show_selection_panel`
-
-  `Syntax utilities <#syntax-utilities>`__
-
-  * :func:`~sublime_lib.list_syntaxes`
-  * :func:`~sublime_lib.get_syntax_for_scope`
-
-  :mod:`~sublime_lib.encodings` submodule
-
-  * :func:`~sublime_lib.encodings.from_sublime`
-  * :func:`~sublime_lib.encodings.to_sublime`
-
-  :mod:`~sublime_lib.flags` submodule
-
-  * :mod:`~sublime_lib.flags`
-
 Settings dictionaries
 ---------------------
 


### PR DESCRIPTION
For #74.

Docs are now on a single page.

I totally redid the theme. The “Read the Docs” theme was very noisy. We can add more ornamentation as desired.

Notably, I removed the search function. With all the docs on one page, the browser's built-in search is good enough.

Feedback requested on organization and aesthetics.