### PR TITLE
Added line_endings argument to new_view, etc.

### DIFF
--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -4,5 +4,5 @@ from .show_selection_panel import show_selection_panel  # noqa: F401
 from .settings_dict import SettingsDict, NamedSettingsDict  # noqa: F401
 from .syntax import list_syntaxes, get_syntax_for_scope  # noqa: F401
 from .view_stream import ViewStream  # noqa: F401
-from .view_utils import new_view, close_view  # noqa: F401
+from .view_utils import new_view, close_view, LineEnding  # noqa: F401
 from .window_utils import new_window, close_window  # noqa: F401

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -17,6 +17,9 @@ def new_view(window, **kwargs):
 
     :argument encoding: The encoding that the view should use when saving.
 
+    :argument line_endings: The kind of line endings to use:
+        ``'Unix'``, ``'Windows'``, or ``'CR'``.
+
     :argument name: The name of the view. This will be shown as the title of the view's tab.
 
     :argument overwrite: If ``True``, the view will be in overwrite mode.
@@ -38,6 +41,11 @@ def new_view(window, **kwargs):
         Incompatible with the `scope` option.
 
     :raise ValueError: if both `scope` and `syntax` are specified.
+    :raise ValueError: if `line_endings` has a value that is not case-insensitively equal to
+        ``'Unix'``, ``'Windows'``, or ``'CR'``.
+
+    ..  versionchanged:: 1.2
+        Added the `line_endings` argument.
     """
     validate_view_options(kwargs)
 
@@ -72,6 +80,9 @@ def validate_view_options(options):
     if 'scope' in options and 'syntax' in options:
         raise ValueError('The "syntax" and "scope" arguments are exclusive.')
 
+    if 'line_endings' in options and options['line_endings'].lower() not in LINE_ENDINGS:
+        raise ValueError('The "line_endings" argument must be "Unix", "Windows", or "CR".')
+
 
 def set_view_options(
     view, *,
@@ -83,7 +94,8 @@ def set_view_options(
     syntax=None,
     scope=None,
     encoding=None,
-    content=None
+    content=None,
+    line_endings=None
 ):
     if name is not None:
         view.set_name(name)
@@ -114,9 +126,14 @@ def set_view_options(
     if encoding is not None:
         view.set_encoding(to_sublime(encoding))
 
+    if line_endings is not None:
+        view.set_line_endings(line_endings)
+
 
 VIEW_OPTIONS = {
     name
     for name, param in inspect.signature(set_view_options).parameters.items()
     if param.kind == inspect.Parameter.KEYWORD_ONLY
 }
+
+LINE_ENDINGS = {'unix', 'windows', 'cr'}

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -94,6 +94,25 @@ class TestViewUtils(TestCase):
 
         self.assertEquals(self.view.encoding(), "UTF-16 LE with BOM")
 
+    def test_line_endings_unix(self):
+        self.view = new_view(self.window, line_endings='unix')
+
+        self.assertEquals(self.view.line_endings(), "Unix")
+
+    def test_line_endings_windows(self):
+        self.view = new_view(self.window, line_endings='WINDOWS')
+
+        self.assertEquals(self.view.line_endings(), "Windows")
+
+    def test_line_endings_cr(self):
+        self.view = new_view(self.window, line_endings='cr')
+
+        self.assertEquals(self.view.line_endings(), "CR")
+
+    def test_line_endings_invalid(self):
+        with self.assertRaises(ValueError):
+            self.view = new_view(self.window, line_endings='other')
+
     def test_content(self):
         self.view = new_view(self.window, content="Hello, World!")
 

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -1,5 +1,5 @@
 import sublime
-from sublime_lib import new_view, close_view
+from sublime_lib import new_view, close_view, LineEnding
 
 from unittest import TestCase
 
@@ -100,12 +100,12 @@ class TestViewUtils(TestCase):
         self.assertEquals(self.view.line_endings(), "Unix")
 
     def test_line_endings_windows(self):
-        self.view = new_view(self.window, line_endings='WINDOWS')
+        self.view = new_view(self.window, line_endings=LineEnding.Windows)
 
         self.assertEquals(self.view.line_endings(), "Windows")
 
     def test_line_endings_cr(self):
-        self.view = new_view(self.window, line_endings='cr')
+        self.view = new_view(self.window, line_endings='\r')
 
         self.assertEquals(self.view.line_endings(), "CR")
 


### PR DESCRIPTION
Valid values are `'Unix'`, `'Windows'`, and `'CR'`. Following Sublime, we don't verify the case (Sublime will normalize the case internally).