### PR TITLE
Pass names directly to enums.

### DIFF
--- a/st3/sublime_lib/_util/enum.py
+++ b/st3/sublime_lib/_util/enum.py
@@ -1,0 +1,51 @@
+from functools import partial
+from ..vendor.python.enum import EnumMeta
+
+
+__all__ = ['ExtensibleConstructorMeta', 'construct_with_alternatives', 'construct_union']
+
+
+class ExtensibleConstructorMeta(EnumMeta):
+    def __call__(cls, *args, **kwargs):
+        return cls.__new__(cls, *args, **kwargs)
+
+
+def extend_constructor(constructor):
+    def decorator(cls):
+        next_constructor = partial(cls.__new__, cls)
+
+        def __new__(cls, *args, **kwargs):
+            return constructor(next_constructor, cls, *args, **kwargs)
+
+        cls.__new__ = __new__
+        return cls
+
+    return decorator
+
+
+def construct_with_alternatives(provider):
+    def constructor(next_constructor, cls, *args, **kwargs):
+        try:
+            return next_constructor(*args, **kwargs)
+        except ValueError:
+            result = provider(cls, *args, **kwargs)
+            if result is None:
+                raise
+            else:
+                return result
+
+    return extend_constructor(constructor)
+
+
+def _construct_union(next_constructor, cls, *args):
+    if args:
+        ret, *rest = iter(next_constructor(arg) for arg in args)
+        for value in rest:
+            ret |= value
+
+        return ret
+    else:
+        return next_constructor(0)
+
+
+construct_union = extend_constructor(_construct_union)

--- a/st3/sublime_lib/flags.py
+++ b/st3/sublime_lib/flags.py
@@ -1,21 +1,32 @@
 """
 Python enumerations for use with Sublime API methods.
 
-Descendants of :class:`IntFlag` each implement the following class method:
+In addition to the standard behavior,
+these enumerations' constructors accept the name of an enumerated value as a string:
 
-..  py:classmethod:: from_strings(strings)
+.. code-block:: python
 
-    Convert each element of strings to this type, then return their union.
+   >>> PointClass(sublime.DIALOG_YES)
+   <DialogResult.YES: 1>
+   >>> PointClass("YES")
+   <DialogResult.YES: 1>
 
-    :raise KeyError: if an element of strings cannot be converted to this type.
+Descendants of :class:`IntFlag` accept zero or more arguments:
 
-    ..  versionadded:: 1.2
+.. code-block:: python
+
+   >>> PointClass("WORD_START", "WORD_END")
+   <PointClass.WORD_END|WORD_START: 3>
+   >>> PointClass()
+   <PointClass.0: 0>
 """
 
 import sublime
 
 from .vendor.python.enum import IntEnum, IntFlag
 from inspect import cleandoc
+
+from ._util.enum import ExtensibleConstructorMeta, construct_union, construct_with_alternatives
 
 
 __all__ = [
@@ -44,17 +55,13 @@ def autodoc(prefix=None):
     return decorator
 
 
-class EnhancedIntFlag(IntFlag):
-    @classmethod
-    def from_strings(cls, strings):
-        ret = cls(0)
-        for string in strings:
-            ret |= cls[string]
-
-        return ret
+construct_from_name = construct_with_alternatives(
+    lambda cls, value: cls.__members__.get(value, None)
+)
 
 
 @autodoc('DIALOG')
+@construct_from_name
 class DialogResult(IntEnum):
     """
     An :class:`~enum.IntEnum` for use with :func:`sublime.yes_no_cancel_dialog`.
@@ -65,7 +72,9 @@ class DialogResult(IntEnum):
 
 
 @autodoc('CLASS')
-class PointClass(EnhancedIntFlag):
+@construct_union
+@construct_from_name
+class PointClass(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with several methods of :class:`sublime.View`:
 
@@ -85,7 +94,9 @@ class PointClass(EnhancedIntFlag):
 
 
 @autodoc()
-class FindOption(EnhancedIntFlag):
+@construct_union
+@construct_from_name
+class FindOption(IntFlag):
     """
     An :class:`~enum.IntFlag` for use with several methods of :class:`sublime.View`:
 
@@ -97,7 +108,9 @@ class FindOption(EnhancedIntFlag):
 
 
 @autodoc()
-class RegionOption(EnhancedIntFlag):
+@construct_union
+@construct_from_name
+class RegionOption(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with :meth:`sublime.View.add_regions`.
     """
@@ -114,7 +127,9 @@ class RegionOption(EnhancedIntFlag):
 
 
 @autodoc()
-class PopupOption(EnhancedIntFlag):
+@construct_union
+@construct_from_name
+class PopupOption(IntFlag):
     """
     An :class:`~enum.IntFlag` for use with :meth:`sublime.View.show_popup`.
     """
@@ -124,7 +139,9 @@ class PopupOption(EnhancedIntFlag):
 
 
 @autodoc('LAYOUT')
-class PhantomLayout(EnhancedIntFlag):
+@construct_union
+@construct_from_name
+class PhantomLayout(IntFlag):
     """
     An :class:`~enum.IntFlag` for use with :class:`sublime.Phantom`.
     """
@@ -134,7 +151,9 @@ class PhantomLayout(EnhancedIntFlag):
 
 
 @autodoc()
-class OpenFileOption(EnhancedIntFlag):
+@construct_union
+@construct_from_name
+class OpenFileOption(IntFlag):
     """
     An :class:`~enum.IntFlag` for use with :meth:`sublime.Window.open_file`.
     """
@@ -143,7 +162,9 @@ class OpenFileOption(EnhancedIntFlag):
 
 
 @autodoc()
-class QuickPanelOption(EnhancedIntFlag):
+@construct_union
+@construct_from_name
+class QuickPanelOption(IntFlag):
     """
     An :class:`~enum.IntFlag` for use with :meth:`sublime.Window.show_quick_panel`.
     """

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -1,6 +1,7 @@
 import inspect
 
 from .vendor.python.enum import Enum
+from ._util.enum import ExtensibleConstructorMeta, construct_with_alternatives
 from .syntax import get_syntax_for_scope
 from .encodings import to_sublime
 
@@ -8,42 +9,23 @@ from .encodings import to_sublime
 __all__ = ['LineEnding', 'new_view', 'close_view']
 
 
-class LineEnding(Enum):
-    """An :class:`enum` of line endings supported by Sublime Text.
+def case_insensitive_value(cls, value):
+    return next((
+        member for name, member in cls.__members__.items()
+        if name.lower() == value.lower()
+    ), None)
+
+
+@construct_with_alternatives(case_insensitive_value)
+class LineEnding(Enum, metaclass=ExtensibleConstructorMeta):
+    """An :class:`Enum` of line endings supported by Sublime Text.
 
     The :class:`LineEnding` constructor accepts either
-    the case-insensitive name (e.g. ``'unix'``) or the value (e.g. ``'\n'``) of a line ending.
-
-    ..  py:attribute:: Unix
-        = ``'\n'``
-
-    ..  py:attribute:: Windows
-        = ``'\r\n'``
-
-    ..  py:attribute:: CR
-        = ``'\r'``
+    the case-insensitive name (e.g. ``'unix'``) or the value (e.g. ``'\\n'``) of a line ending.
     """
     Unix = '\n'
     Windows = '\r\n'
     CR = '\r'
-
-
-def from_string(cls, value):
-    try:
-        return super(cls, cls).__new__(cls, value)
-    except ValueError:
-        try:
-            return next(
-                member for name, member in cls.__members__.items()
-                if name.lower() == value.lower()
-            )
-        except StopIteration:
-            pass
-
-        raise
-
-
-setattr(LineEnding, '__new__', from_string)
 
 
 def new_view(window, **kwargs):

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -9,6 +9,7 @@ class TestFlags(TestCase):
     def _test_enum(self, enum, prefix=''):
         for item in enum:
             self.assertEqual(item, getattr(sublime, prefix + item.name))
+            self.assertEqual(item, enum(item.name))
 
     def test_flags(self):
         self._test_enum(flags.DialogResult, 'DIALOG_')
@@ -23,12 +24,12 @@ class TestFlags(TestCase):
 
     def test_from_strings(self):
         self.assertEqual(
-            flags.RegionOption.from_strings(['DRAW_EMPTY', 'HIDE_ON_MINIMAP']),
+            flags.RegionOption('DRAW_EMPTY', 'HIDE_ON_MINIMAP'),
             flags.RegionOption.DRAW_EMPTY | flags.RegionOption.HIDE_ON_MINIMAP
         )
 
     def test_from_strings_empty(self):
         self.assertEqual(
-            flags.RegionOption.from_strings([]),
+            flags.RegionOption(),
             flags.RegionOption(0)
         )


### PR DESCRIPTION
When invoking an enum constructor, normally you can only pass values (e.g. `RegionOption(1)`). This PR extends the enums in `flags` to also accept a string (e.g. `RegionOption('DRAW_EMPTY')`). Those enums that extend `IntFlag` may accept multiple arguments (e.g. `RegionOption('DRAW_EMPTY', 'DRAW_SQUIGGLY_UNDERLINE')`). The `LineEnding` enum now uses the same underlying implementation.

Hopefully, this should be as simple and consistent as possible, without needing to define a bunch of extra methods or patch enum classes individually. To construct a `RegionOption` from a list of names, you can now call `RegionOption(*names)`.

The implementation of this is a bit complicated because the implementation of `Enum` is complicated. When you pass multiple arguments to an enum constructor, it assumes that you're trying to define a new sort of enum, not access an element of the receiver enum. The `ExtensibleConstructorMeta` metaclass fixes this quirk. The constructor can be extended via decorators.