### PR TITLE
Fixed makefile for new docs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 python: 3.6
 
 install:
-  - pip install sphinx sphinx_rtd_theme
+  - pip install sphinx
 
-script: make source html
+script: make clean html
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python: 3.6
 install:
   - pip install sphinx
 
-script: make clean html
+script: make -C docs clean html
 
 git:
   depth: 1

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,11 @@
 # You can set these variables from the command line.
 SOURCEDIR     = docs/source
 BUILDDIR      = docs
-MODULEDIR     = st3
 
-.PHONY: source clean
-
-source:
-	SPHINX_APIDOC_OPTIONS=members sphinx-apidoc --force --module-first -o "$(SOURCEDIR)/modules" "$(MODULEDIR)"
+.PHONY: clean
 
 html:
 	sphinx-build -M html "$(SOURCEDIR)" "$(BUILDDIR)"
 
 clean:
-	rm -rf docs/source/modules docs/doctrees docs/html
+	rm -rf doctrees html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,8 +1,8 @@
 # Minimal makefile for Sphinx documentation
 
 # You can set these variables from the command line.
-SOURCEDIR     = docs/source
-BUILDDIR      = docs
+SOURCEDIR     = source
+BUILDDIR      = .
 
 .PHONY: clean
 


### PR DESCRIPTION
Since we have the manual `index.rst`, we don't need `make source`. Should fix #86. Also fixes #85.