### PR TITLE
from_file_path works with installed resources.

### DIFF
--- a/st3/sublime_lib/resource_path.py
+++ b/st3/sublime_lib/resource_path.py
@@ -108,10 +108,13 @@ class ResourcePath():
 
         for base in get_installed_resource_roots():
             try:
-                package, *rest = file_path.relative_to(base).parts
+                rel = file_path.relative_to(base).parts
             except ValueError:
                 pass
             else:
+                if rel == ():
+                    return cls('Packages')
+                package, *rest = rel
                 package_path = cls('Packages', package)
                 if package_path.suffix == '.sublime-package':
                     return package_path.with_suffix('').joinpath(*rest)

--- a/st3/sublime_lib/resource_path.py
+++ b/st3/sublime_lib/resource_path.py
@@ -113,9 +113,8 @@ class ResourcePath():
                 pass
             else:
                 package_path = cls('Packages', package)
-                if package_path.suffix != '.sublime-package':
-                    continue
-                return package_path.with_suffix('').joinpath(*rest)
+                if package_path.suffix == '.sublime-package':
+                    return package_path.with_suffix('').joinpath(*rest)
 
         raise ValueError("Path {!r} does not correspond to any resource path.".format(file_path))
 

--- a/tests/test_resource_path.py
+++ b/tests/test_resource_path.py
@@ -44,6 +44,30 @@ class TestResourcePath(DeferrableTestCase):
             ResourcePath("Cache/test_package")
         )
 
+    def test_from_file_path_installed_packages(self):
+        self.assertEqual(
+            ResourcePath.from_file_path(
+                Path(sublime.installed_packages_path(), 'test_package.sublime-package', 'foo.py')
+            ),
+            ResourcePath("Packages/test_package/foo.py")
+        )
+
+    def test_from_file_path_installed_packages_not_installed(self):
+        with self.assertRaises(ValueError):
+            ResourcePath.from_file_path(
+                Path(sublime.installed_packages_path(), 'test_package', 'foo.py')
+            ),
+
+    def test_from_file_path_default_packages(self):
+        self.assertEqual(
+            ResourcePath.from_file_path(
+                Path(sublime.executable_path()).parent.joinpath(
+                    'Packages',' test_package.sublime-package',' foo.py'
+                )
+            ),
+            ResourcePath("Packages/test_package/foo.py")
+        )
+
     def test_from_file_path_error(self):
         with self.assertRaises(ValueError):
             ResourcePath.from_file_path(Path('/test_package')),

--- a/tests/test_resource_path.py
+++ b/tests/test_resource_path.py
@@ -62,7 +62,7 @@ class TestResourcePath(DeferrableTestCase):
         self.assertEqual(
             ResourcePath.from_file_path(
                 Path(sublime.executable_path()).parent.joinpath(
-                    'Packages',' test_package.sublime-package',' foo.py'
+                    'Packages', 'test_package.sublime-package', 'foo.py'
                 )
             ),
             ResourcePath("Packages/test_package/foo.py")

--- a/tests/test_resource_path.py
+++ b/tests/test_resource_path.py
@@ -58,6 +58,12 @@ class TestResourcePath(DeferrableTestCase):
                 Path(sublime.installed_packages_path(), 'test_package', 'foo.py')
             ),
 
+    def test_from_file_path_installed_packages_root(self):
+        self.assertEqual(
+            ResourcePath.from_file_path(Path(sublime.installed_packages_path())),
+            ResourcePath("Packages")
+        )
+
     def test_from_file_path_default_packages(self):
         self.assertEqual(
             ResourcePath.from_file_path(
@@ -66,6 +72,14 @@ class TestResourcePath(DeferrableTestCase):
                 )
             ),
             ResourcePath("Packages/test_package/foo.py")
+        )
+
+    def test_from_file_path_default_packages_root(self):
+        self.assertEqual(
+            ResourcePath.from_file_path(
+                Path(sublime.executable_path()).parent / 'Packages'
+            ),
+            ResourcePath("Packages")
         )
 
     def test_from_file_path_error(self):


### PR DESCRIPTION
`from_file_path` would raise `ValueError` for installed package paths such as `$wherever/Installed Packages/My Package.sublime-syntax/foo.py`. This is probably incorrect, and it's problematic because it could cause a package relying on `from_file_path` to work as expected when cloned into `Packages` but fail when installed into `Installed Packages`.

Actual example I found while testing JS Custom:

```py
PACKAGE_NAME = ResourcePath.from_file_path(__file__).package
```

I discovered the bug when doing the final end-to-end tests before release.

This PR makes `from_file_path` check both the installed packages path and the default packages path. Code that calls `from_file_path` on Sublime-provided paths inside the package should work identically no matter how the package is installed. The documentation is expanded to clarify, but the method summary and error descriptions are unchanged. Likewise, tests are added, but no existing tests need be changed.

Although this is in some sense new functionality, I think it's a bug fix rather than a new feature. The new behavior is consistent with the original docs, wherease raising `ValueError("Path {!r} does not correspond to any resource path.")` for a Sublime-provided path in an installed package seems like incorrect behavior. If this solution makes sense, we should release it in a 1.2.1 release as a bug fix.

Alternatively, we could modify the documentation to specifically call out the old behavior. We would probably want to do this ASAP. Then we could provide the new behavior in 1.3 as a new feature (via a flag argument or something).

I favor fixing it now because it seems very unlikely that anyone would rely on the old behavior but very likely that a developer would expect the new behavior, not double-check that the code works when installed, and release a critical bug.