### PR TITLE
Added metaclass to all necessary enums.

### DIFF
--- a/st3/sublime_lib/flags.py
+++ b/st3/sublime_lib/flags.py
@@ -99,7 +99,7 @@ class PointClass(IntFlag, metaclass=ExtensibleConstructorMeta):
 @autodoc()
 @construct_union
 @construct_from_name
-class FindOption(IntFlag):
+class FindOption(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with several methods of :class:`sublime.View`:
 
@@ -132,7 +132,7 @@ class RegionOption(IntFlag, metaclass=ExtensibleConstructorMeta):
 @autodoc()
 @construct_union
 @construct_from_name
-class PopupOption(IntFlag):
+class PopupOption(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with :meth:`sublime.View.show_popup`.
     """
@@ -144,7 +144,7 @@ class PopupOption(IntFlag):
 @autodoc('LAYOUT')
 @construct_union
 @construct_from_name
-class PhantomLayout(IntFlag):
+class PhantomLayout(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with :class:`sublime.Phantom`.
     """
@@ -156,7 +156,7 @@ class PhantomLayout(IntFlag):
 @autodoc()
 @construct_union
 @construct_from_name
-class OpenFileOption(IntFlag):
+class OpenFileOption(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with :meth:`sublime.Window.open_file`.
     """
@@ -167,7 +167,7 @@ class OpenFileOption(IntFlag):
 @autodoc()
 @construct_union
 @construct_from_name
-class QuickPanelOption(IntFlag):
+class QuickPanelOption(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with :meth:`sublime.Window.show_quick_panel`.
     """

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,6 +1,9 @@
 import sublime
 import sublime_lib.flags as flags
 
+from sublime_lib.vendor.python.enum import IntFlag
+
+from functools import reduce
 from unittest import TestCase
 
 
@@ -10,6 +13,12 @@ class TestFlags(TestCase):
         for item in enum:
             self.assertEqual(item, getattr(sublime, prefix + item.name))
             self.assertEqual(item, enum(item.name))
+
+        if issubclass(enum, IntFlag):
+            self.assertEqual(
+                enum(*[item.name for item in enum]),
+                reduce(lambda a, b: a | b, enum)
+            )
 
     def test_flags(self):
         self._test_enum(flags.DialogResult, 'DIALOG_')


### PR DESCRIPTION
Not all `IntFlag` enums had the necessary metaclass set. This led to an error when constructing such an enum from multiple arguments. This PR corrects the bug and adds tests to cover it.

This should probably go out as 1.2.2.