### PR TITLE
Accept selection panel flags in more formats.

### DIFF
--- a/st3/sublime_lib/flags.py
+++ b/st3/sublime_lib/flags.py
@@ -99,7 +99,7 @@ class PointClass(IntFlag, metaclass=ExtensibleConstructorMeta):
 @autodoc()
 @construct_union
 @construct_from_name
-class FindOption(IntFlag):
+class FindOption(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with several methods of :class:`sublime.View`:
 
@@ -132,7 +132,7 @@ class RegionOption(IntFlag, metaclass=ExtensibleConstructorMeta):
 @autodoc()
 @construct_union
 @construct_from_name
-class PopupOption(IntFlag):
+class PopupOption(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with :meth:`sublime.View.show_popup`.
     """
@@ -144,7 +144,7 @@ class PopupOption(IntFlag):
 @autodoc('LAYOUT')
 @construct_union
 @construct_from_name
-class PhantomLayout(IntFlag):
+class PhantomLayout(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with :class:`sublime.Phantom`.
     """
@@ -156,7 +156,7 @@ class PhantomLayout(IntFlag):
 @autodoc()
 @construct_union
 @construct_from_name
-class OpenFileOption(IntFlag):
+class OpenFileOption(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with :meth:`sublime.Window.open_file`.
     """
@@ -167,7 +167,7 @@ class OpenFileOption(IntFlag):
 @autodoc()
 @construct_union
 @construct_from_name
-class QuickPanelOption(IntFlag):
+class QuickPanelOption(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     An :class:`~enum.IntFlag` for use with :meth:`sublime.Window.show_quick_panel`.
     """

--- a/st3/sublime_lib/show_selection_panel.py
+++ b/st3/sublime_lib/show_selection_panel.py
@@ -1,5 +1,6 @@
-from ._util.collections import is_sequence_not_str
+from ._util.collections import is_sequence_not_str, isiterable
 from ._util.named_value import NamedValue
+from .flags import QuickPanelOption
 
 
 __all__ = ['show_selection_panel', 'NO_SELECTION']
@@ -28,8 +29,9 @@ def show_selection_panel(
 
     Optional keyword arguments:
 
-    :argument flags: A bitwise OR of :const:`sublime.MONOSPACE_FONT` and
-        :const:`sublime.KEEP_OPEN_ON_FOCUS_LOST`.
+    :argument flags: A :class:`sublime_lib.flags.QuickPanelOption`,
+        a value convertible to :class:`~sublime_lib.flags.QuickPanelOption`,
+        or an iterable of such values.
 
     :argument labels: A value determining what to show as the label for each item:
 
@@ -58,12 +60,15 @@ def show_selection_panel(
     :argument on_highlight: A callback accepting a value from `items` to be
         invoked every time the user changes the highlighted item in the panel.
 
-    :raises ValueError: if `items` is empty.
+    :raise ValueError: if `items` is empty.
 
-    :raises ValueError: if `selected` is given and the value is not in `items`.
+    :raise ValueError: if `selected` is given and the value is not in `items`.
 
-    :raises ValueError: if some labels are sequences but not others
+    :raise ValueError: if some labels are sequences but not others
         or if labels are sequences of inconsistent length.
+
+    :raise ValueError: if `flags` cannot be converted
+        to :class:`sublime_lib.flags.QuickPanelOption`.
 
     ..  versionadded:: 1.2
     """
@@ -105,6 +110,11 @@ def show_selection_panel(
         on_highlight_callback = lambda index: on_highlight(items[index])
     else:
         on_highlight_callback = None
+
+    if isiterable(flags) and not isinstance(flags, str):
+        flags = QuickPanelOption(*flags)
+    else:
+        flags = QuickPanelOption(flags)
 
     # The signature in the API docs is wrong.
     # See https://github.com/SublimeTextIssues/Core/issues/2290

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,6 +1,9 @@
 import sublime
 import sublime_lib.flags as flags
 
+from sublime_lib.vendor.python.enum import IntFlag
+
+from functools import reduce
 from unittest import TestCase
 
 
@@ -10,6 +13,12 @@ class TestFlags(TestCase):
         for item in enum:
             self.assertEqual(item, getattr(sublime, prefix + item.name))
             self.assertEqual(item, enum(item.name))
+
+        if issubclass(enum, IntFlag):
+            self.assertEqual(
+                enum(*[item.name for item in enum]),
+                reduce(lambda a, b: a | b, enum)
+            )
 
     def test_flags(self):
         self._test_enum(flags.DialogResult, 'DIALOG_')

--- a/tests/test_selection_panel.py
+++ b/tests/test_selection_panel.py
@@ -199,6 +199,22 @@ class TestSelectionPanel(TestCase):
             flags=flags
         )
 
+    def test_flags_conversion(self):
+        window = WindowMock()
+
+        flags = ['MONOSPACE_FONT', 'KEEP_OPEN_ON_FOCUS_LOST']
+
+        show_selection_panel(
+            window=window,
+            items=['a', 'b', 'c'],
+            flags=flags
+        )
+
+        assert_called_once_with_partial(
+            window.show_quick_panel,
+            flags=(sublime.MONOSPACE_FONT | sublime.KEEP_OPEN_ON_FOCUS_LOST)
+        )
+
     def test_labels_function(self):
         window = WindowMock()
 


### PR DESCRIPTION
Depends on #94. Before merging this, we should resolve that PR and (if appropriate) release the fix.

Previously, the `flags` argument of `show_selection_panel` was passed directly to `Window.show_quick_panel`; therefore, it had to be an int. The user could use `sublime_lib.flags.QuickPanelOption` manually.

This PR lets the user cut out the middleman and directly pass values convertible to `QuickPanelOption`, such as `"MONOSPACE_FONT"`. An iterable of values will all be passed to `QuickPanelOption`, such as `("MONOSPACE_FONT", "KEEP_OPEN_ON_FOCUS_LOST")`.

As a side effect, the argument checking is more explicit. Invalid values will raise an error as documented here rather than ambiguously in `Window.show_quick_panel`.