### PR TITLE
Added Panel class.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,10 +16,11 @@ Settings dictionaries
 .. autoclass:: sublime_lib.SettingsDict
 .. autoclass:: sublime_lib.NamedSettingsDict
 
-Output streams
---------------
+Output streams and panels
+-------------------------
 
 .. autoclass:: sublime_lib.ViewStream
+.. autoclass:: sublime_lib.Panel
 .. autoclass:: sublime_lib.OutputPanel
 
 Resource paths

--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -1,4 +1,4 @@
-from .output_panel import Panel, OutputPanel  # noqa: F401
+from .panel import Panel, OutputPanel  # noqa: F401
 from .resource_path import ResourcePath  # noqa: F401
 from .show_selection_panel import show_selection_panel, NO_SELECTION  # noqa: F401
 from .settings_dict import SettingsDict, NamedSettingsDict  # noqa: F401

--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -1,4 +1,4 @@
-from .output_panel import OutputPanel  # noqa: F401
+from .output_panel import Panel, OutputPanel  # noqa: F401
 from .resource_path import ResourcePath  # noqa: F401
 from .show_selection_panel import show_selection_panel, NO_SELECTION  # noqa: F401
 from .settings_dict import SettingsDict, NamedSettingsDict  # noqa: F401

--- a/st3/sublime_lib/_util/guard.py
+++ b/st3/sublime_lib/_util/guard.py
@@ -1,0 +1,17 @@
+from functools import wraps
+
+
+def define_guard(guard_fn):
+    def decorator(wrapped):
+        @wraps(wrapped)
+        def wrapper_guards(self, *args, **kwargs):
+            ret_val = guard_fn(self)
+            if hasattr(ret_val, '__enter__'):
+                with ret_val:
+                    return wrapped(self, *args, **kwargs)
+            else:
+                return wrapped(self, *args, **kwargs)
+
+        return wrapper_guards
+
+    return decorator

--- a/st3/sublime_lib/output_panel.py
+++ b/st3/sublime_lib/output_panel.py
@@ -1,12 +1,70 @@
 from .view_stream import ViewStream
 from .view_utils import set_view_options, validate_view_options
+from ._util.guard import define_guard
+
+__all__ = ['Panel', 'OutputPanel']
 
 
-__all__ = ['OutputPanel']
+class Panel():
+    """An abstraction of a panel, such as the console or an output panel.
+
+    :raise ValueError: if `window` has no panel called `panel_name`.
+
+    All :class:`Panel` methods except for :meth:`exists()`
+    will raise a ``ValueError`` if the panel does not exist.
+    Descendant classes may override :meth:`exists()` to customize this behavior.
+    """
+
+    def __init__(self, window, panel_name):
+        self.window = window
+        self.panel_name = panel_name
+
+        self._checkExists()
+
+    def _checkExists(self):
+        # if self.must_exist and not self.exists():
+        if not self.exists():
+            raise ValueError("Panel {} does not exist.".format(self.panel_name))
+
+    @define_guard
+    def guard_exists(self):
+        self._checkExists()
+
+    def exists(self):
+        """Return ``True`` if the panel exists, or ``False`` otherwise.
+
+        This implementation checks :meth:`sublime.Window.panels`,
+        so it will return ``False`` for unlisted panels.
+        """
+        return self.panel_name in self.window.panels()
+
+    @guard_exists
+    def is_visible(self):
+        """Return ``True`` if the panel is currently visible."""
+        return self.window.active_panel() == self.panel_name
+
+    @guard_exists
+    def show(self):
+        """Show the panel, hiding any other visible panel."""
+        self.window.run_command("show_panel", {"panel": self.panel_name})
+
+    @guard_exists
+    def hide(self):
+        """Hide the panel."""
+        self.window.run_command("hide_panel", {"panel": self.panel_name})
+
+    @guard_exists
+    def toggle_visibility(self):
+        """If the panel is visible, hide it; otherwise, show it."""
+        if self.is_visible():
+            self.hide()
+        else:
+            self.show()
 
 
-class OutputPanel(ViewStream):
-    """A :class:`~sublime_lib.view_stream.ViewStream`
+class OutputPanel(ViewStream, Panel):
+    """
+    A subclass of :class:`~sublime_lib.ViewStream` and :class:`~sublime_lib.Panel`
     wrapping an output panel in the given `window` with the given `name`.
 
     :raise ValueError: if `window` has no output panel called `name`.
@@ -42,9 +100,9 @@ class OutputPanel(ViewStream):
         if view is None:
             raise ValueError('Output panel "%s" does not exist.' % name)
 
-        super().__init__(view, force_writes=force_writes, follow_cursor=follow_cursor)
+        ViewStream.__init__(self, view, force_writes=force_writes, follow_cursor=follow_cursor)
+        Panel.__init__(self, window, "output." + name)
 
-        self.window = window
         self.name = name
 
     @property
@@ -54,30 +112,15 @@ class OutputPanel(ViewStream):
         Generally, API methods specific to output panels will use :attr:`name`,
         while methods that work with any panels will use :attr:`full_name`.
         """
-        return "output.%s" % self.name
+        return self.panel_name
 
-    @ViewStream.guard_validity
-    def is_visible(self):
-        """Return ``True`` if the output panel is currently visible."""
-        return self.window.active_panel() == self.full_name
+    def exists(self):
+        """Return ``True`` if the panel exists, or ``False`` otherwise.
 
-    @ViewStream.guard_validity
-    def show(self):
-        """Show the output panel, hiding any other visible panel."""
-        self.window.run_command("show_panel", {"panel": self.full_name})
-
-    @ViewStream.guard_validity
-    def hide(self):
-        """Hide the output panel."""
-        self.window.run_command("hide_panel", {"panel": self.full_name})
-
-    @ViewStream.guard_validity
-    def toggle_visibility(self):
-        """If the output panel is visible, hide it; otherwise, show it."""
-        if self.is_visible():
-            self.hide()
-        else:
-            self.show()
+        This implementation checks that the encapsulated :class:`~sublime.View` is valid,
+        so it will return ``True`` even for unlisted panels.
+        """
+        return self.view.is_valid()
 
     def destroy(self):
         """Destroy the output panel."""

--- a/st3/sublime_lib/panel.py
+++ b/st3/sublime_lib/panel.py
@@ -13,6 +13,10 @@ class Panel():
     All :class:`Panel` methods except for :meth:`exists()`
     will raise a ``ValueError`` if the panel does not exist.
     Descendant classes may override :meth:`exists()` to customize this behavior.
+
+    .. py:attribute:: panel_name
+        
+        The name of the panel as it is listed in :meth:`sublime.Window.panels()`.
     """
 
     def __init__(self, window, panel_name):
@@ -22,7 +26,6 @@ class Panel():
         self._checkExists()
 
     def _checkExists(self):
-        # if self.must_exist and not self.exists():
         if not self.exists():
             raise ValueError("Panel {} does not exist.".format(self.panel_name))
 
@@ -33,7 +36,7 @@ class Panel():
     def exists(self):
         """Return ``True`` if the panel exists, or ``False`` otherwise.
 
-        This implementation checks :meth:`sublime.Window.panels`,
+        This implementation checks :meth:`sublime.Window.panels()`,
         so it will return ``False`` for unlisted panels.
         """
         return self.panel_name in self.window.panels()

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -1,24 +1,9 @@
 from sublime import Region
 
 from contextlib import contextmanager
-from functools import wraps
 from io import SEEK_SET, SEEK_CUR, SEEK_END, TextIOBase
 
-
-def define_guard(guard_fn):
-    def decorator(wrapped):
-        @wraps(wrapped)
-        def wrapper_guards(self, *args, **kwargs):
-            ret_val = guard_fn(self)
-            if hasattr(ret_val, '__enter__'):
-                with ret_val:
-                    return wrapped(self, *args, **kwargs)
-            else:
-                return wrapped(self, *args, **kwargs)
-
-        return wrapper_guards
-
-    return decorator
+from ._util.guard import define_guard
 
 
 class ViewStream(TextIOBase):

--- a/tests/test_output_panel.py
+++ b/tests/test_output_panel.py
@@ -104,7 +104,9 @@ class TestOutputPanel(TestCase):
         self.assertEqual(self.panel.view.id(), other.view.id())
 
         self.panel.destroy()
-        self.assertRaises(ValueError, other.tell)
+        with self.assertRaises(ValueError):
+            other.tell()
 
     def test_init_nonexistent_error(self):
-        self.assertRaises(ValueError, OutputPanel, self.window, 'does_not_exist')
+        with self.assertRaises(ValueError):
+            OutputPanel(self.window, 'nonexistent_output_panel')

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -1,0 +1,47 @@
+import sublime
+from sublime_lib import Panel
+
+from unittest import TestCase
+
+
+class TestOutputPanel(TestCase):
+
+    def setUp(self):
+        self.window = sublime.active_window()
+        self.panel_to_restore = self.window.active_panel()
+
+    def tearDown(self):
+        if self.panel_to_restore:
+            self.window.run_command("show_panel", {"panel": self.panel_to_restore})
+
+    def test_exists(self):
+        panel = Panel(self.window, "console")
+        self.assertIn("console", self.window.panels())
+        self.assertTrue(panel.exists())
+
+    def test_not_exists(self):
+        with self.assertRaises(ValueError):
+            Panel(self.window, "nonexistent_panel")
+
+    def test_show_hide(self):
+        panel = Panel(self.window, "console")
+
+        panel.show()
+        self.assertTrue(panel.is_visible())
+        self.assertEqual(self.window.active_panel(), "console")
+
+        panel.hide()
+        self.assertFalse(panel.is_visible())
+        self.assertNotEqual(self.window.active_panel(), "console")
+
+        panel.show()
+        self.assertTrue(panel.is_visible())
+        self.assertEqual(self.window.active_panel(), "console")
+
+        panel.toggle_visibility()
+        self.assertFalse(panel.is_visible())
+        self.assertNotEqual(self.window.active_panel(), "console")
+
+        panel.toggle_visibility()
+        self.assertTrue(panel.is_visible())
+        self.assertEqual(self.window.active_panel(), "console")


### PR DESCRIPTION
The existing `OutputPanel` class contains a lot of functionality that could be useful for any panel, such as the console. This PR factors out that functionality into a new `Panel` class. `OutputPanel` then extends both `ViewStream` and `Panel`. (Thankfully, this isn't a mess in Python as it would be in many other languages.)

The behavior of `OutputPanel` is unchanged, except that when you call inherited `Panel` methods on an `OutputPanel` whose view is invalid, the exception message will be slightly different. (It will still raise the same exception under the same circumstances.)

"Before" example, based on real code with irrelevant bits removed:

```python
if settings["open_console"] and self.window.active_panel() != "console":
    self.window.run_command("show_panel", {"panel": "console"})

try:
    reload_package(pkg_name)
except Exception:
    if settings["open_console_on_failure"]:
        self.window.run_command("show_panel", {"panel": "console"})
    raise
finally:

if settings["close_console_on_success"]:
    self.window.run_command("hide_panel", {"panel": "console"})
```

After:

```python
console = Panel("console")

if settings["open_console"] and not console.is_visible():
    console.show()

try:
    reload_package(pkg_name)
except Exception:
    if settings["open_console_on_failure"]:
        console.show()
    raise
finally:

if settings["close_console_on_success"]:
    console.hide()
```

Notes:
- I factored out `define_guard` under `_util`.
- The OutputPanel tests are functionally the same, but I modified them to use `assertRaises` with a `with` statement, which is much nicer.
- `OutputPanel.full_name` is now redundant with `Panel.panel_name` (but remains, of course, for compatibility).