### PR TITLE
Added `ResourcePath.add_suffix` and `.remove_suffix`.

### DIFF
--- a/st3/sublime_lib/resource_path.py
+++ b/st3/sublime_lib/resource_path.py
@@ -263,6 +263,50 @@ class ResourcePath():
         else:
             return self.parent / name
 
+    def add_suffix(self, suffix):
+        """
+        Return a new path with the suffix added.
+        """
+        return self.with_name(self.name + suffix)
+
+    def remove_suffix(self, suffix=None, *, must_remove=True):
+        """
+        Return a new path with the suffix removed.
+
+        If `suffix` is ``None`` (the default), then ``self.suffix`` will be removed.
+        If `suffix` is a string, then only that suffix will be removed.
+        Otherwise, if `suffix` is iterable,
+        then the longest possible item in `suffix` will be removed.
+
+        :raise ValueError: if `must_remove` is ``True`` (the default)
+            and no suffix can be removed.
+        """
+        new_name = None
+
+        if suffix is None:
+            if self.suffix:
+                new_name = self.stem
+        else:
+            if isinstance(suffix, str):
+                suffixes = (suffix,)
+            else:
+                suffixes = sorted(suffix, key=len, reverse=True)
+
+            old_name = self.name
+            new_name = next((
+                old_name[:i]
+                for s in suffixes
+                for i in (old_name.rfind(s),)
+                if i > 0
+            ), None)
+
+        if new_name is not None:
+            return self.with_name(new_name)
+        elif must_remove:
+            raise ValueError('Cannot remove suffix {!r} from {!r}.'.format(suffix, self))
+        else:
+            return self
+
     def with_suffix(self, suffix):
         """
         Return a new path with the suffix changed.
@@ -270,6 +314,8 @@ class ResourcePath():
         If the original path doesn’t have a suffix, the new suffix is appended
         instead. If the new suffix is an empty string, the original suffix is
         removed.
+
+        Equivalent to ``self.remove_suffix(must_remove=False).add_suffix(suffix)``.
         """
         return self.with_name(self.stem + suffix)
 

--- a/st3/sublime_lib/resource_path.py
+++ b/st3/sublime_lib/resource_path.py
@@ -109,15 +109,15 @@ class ResourcePath():
         for base in get_installed_resource_roots():
             try:
                 rel = file_path.relative_to(base).parts
-            except ValueError:
-                pass
-            else:
+
                 if rel == ():
                     return cls('Packages')
-                package, *rest = rel
-                package_path = cls('Packages', package)
-                if package_path.suffix == '.sublime-package':
-                    return package_path.with_suffix('').joinpath(*rest)
+                else:
+                    package, *rest = rel
+                    return (cls('Packages', package)
+                            .remove_suffix('.sublime-package').joinpath(*rest))
+            except ValueError:
+                pass
 
         raise ValueError("Path {!r} does not correspond to any resource path.".format(file_path))
 

--- a/tests/test_pure_resource_path.py
+++ b/tests/test_pure_resource_path.py
@@ -227,6 +227,78 @@ class TestPureResourcePath(TestCase):
             ResourcePath("Cache")
         )
 
+    def test_add_suffix(self):
+        self.assertEqual(
+            ResourcePath("Packages/Foo/bar").add_suffix('.py'),
+            ResourcePath("Packages/Foo/bar.py")
+        )
+
+    def test_remove_suffix(self):
+        self.assertEqual(
+            ResourcePath("Packages/Foo/bar.py").remove_suffix(),
+            ResourcePath("Packages/Foo/bar")
+        )
+
+    def test_remove_suffix_none(self):
+        self.assertEqual(
+            ResourcePath("Packages/Foo/bar").remove_suffix(must_remove=False),
+            ResourcePath("Packages/Foo/bar")
+        )
+
+    def test_remove_suffix_none_error(self):
+        with self.assertRaises(ValueError):
+            ResourcePath("Packages/Foo/bar").remove_suffix()
+
+    def test_remove_suffix_specified(self):
+        self.assertEqual(
+            ResourcePath("Packages/Foo/bar.py").remove_suffix('.py'),
+            ResourcePath("Packages/Foo/bar")
+        )
+
+    def test_remove_suffix_specified_no_match(self):
+        self.assertEqual(
+            ResourcePath("Packages/Foo/bar.py").remove_suffix('.zip', must_remove=False),
+            ResourcePath("Packages/Foo/bar.py")
+        )
+
+    def test_remove_suffix_specified_no_match_error(self):
+        with self.assertRaises(ValueError):
+            ResourcePath("Packages/Foo/bar.py").remove_suffix('.zip')
+
+    def test_remove_suffix_specified_no_dot(self):
+        self.assertEqual(
+            ResourcePath("Packages/Foo/bar.py").remove_suffix('r.py'),
+            ResourcePath("Packages/Foo/ba")
+        )
+
+    def test_remove_suffix_specified_entire_name(self):
+        self.assertEqual(
+            ResourcePath("Packages/Foo/bar.py").remove_suffix('bar.py', must_remove=False),
+            ResourcePath("Packages/Foo/bar.py")
+        )
+
+    def test_remove_suffix_specified_entire_name_error(self):
+        with self.assertRaises(ValueError):
+            ResourcePath("Packages/Foo/bar.py").remove_suffix('bar.py')
+
+    def test_remove_suffix_multiple(self):
+        self.assertEqual(
+            ResourcePath("Packages/Foo/bar.py").remove_suffix(['.zip', '.py']),
+            ResourcePath("Packages/Foo/bar")
+        )
+
+    def test_remove_suffix_multiple_matches(self):
+        self.assertEqual(
+            ResourcePath("Packages/Foo/bar.tar.gz").remove_suffix(['.tar.gz', '.gz']),
+            ResourcePath("Packages/Foo/bar")
+        )
+
+    def test_remove_suffix_multiple_matches_backward(self):
+        self.assertEqual(
+            ResourcePath("Packages/Foo/bar.tar.gz").remove_suffix(['.gz', '.tar.gz']),
+            ResourcePath("Packages/Foo/bar")
+        )
+
     def test_with_suffix(self):
         self.assertEqual(
             ResourcePath("Packages/Foo/bar.tar.gz").with_suffix('.bz2'),


### PR DESCRIPTION
We have `with_suffix` copied from pathlib, but `with_suffix` is kind of annoying:

- You can't easily add a suffix without removing one.
- You can remove a suffix without adding one, but you have to pass an explicit empty string.
- It's hard to tell whether the original name had a suffix that was removed.

To solve these problems, I've created `add_suffix` and `remove_suffix`. `add_suffix` will unconditionally append its argument to the name. `remove_suffix`:

- Will raise `ValueError` if it can't do its job (unless you pass `must_remove=False`).
- Allows you to specify an optional suffix or collection of suffixes to remove, including suffixes that may differ from the `suffix` property.

Examples:

```python
path.remove_suffix('.sublime-package') # raise ValueError if the file extension is wrong
path.remove_suffix({'.htm', '.html', '.md', '.rst'}, must_remove=False)
```