### PR TITLE
Explicit error handling for encodings.

### DIFF
--- a/st3/sublime_lib/encodings.py
+++ b/st3/sublime_lib/encodings.py
@@ -6,24 +6,34 @@ __all__ = ['from_sublime', 'to_sublime']
 def from_sublime(name):
     """Translate `name` from a Sublime encoding name to a standard Python encoding name.
 
+    :raise ValueError: if `name` is not a Sublime encoding.
+
     .. code-block:: python
 
        >>> from_sublime("Western (Windows 1252)")
        "cp1252"
     """
 
-    return SUBLIME_TO_STANDARD.get(name, None)
+    try:
+        return SUBLIME_TO_STANDARD[name]
+    except KeyError:
+        raise ValueError("Unknown Sublime encoding {!r}.".format(name)) from None
 
 
 def to_sublime(name):
     """Translate `name` from a standard Python encoding name to a Sublime encoding name.
+
+    :raise ValueError: if `name` is not a Python encoding.
 
     .. code-block:: python
 
        >>> to_sublime("cp1252")
        "Western (Windows 1252)"
     """
-    return STANDARD_TO_SUBLIME.get(lookup(name).name, None)
+    try:
+        return STANDARD_TO_SUBLIME[lookup(name).name]
+    except LookupError:
+        raise ValueError("Unknown Python encoding {!r}.".format(name)) from None
 
 
 SUBLIME_TO_STANDARD = {  # noqa: E121

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -73,6 +73,7 @@ def new_view(window, **kwargs):
         Incompatible with the `scope` option.
 
     :raise ValueError: if both `scope` and `syntax` are specified.
+    :raise ValueError: if `encoding` is not a Python encoding name.
     :raise ValueError: if `line_endings` cannot be converted to :class:`LineEnding`.
 
     ..  versionchanged:: 1.2

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -11,8 +11,16 @@ class TestEncodings(TestCase):
             "cp1252"
         )
 
+    def test_from_error(self):
+        with self.assertRaises(ValueError):
+            from_sublime("Nonexistent")
+
     def test_to(self):
         self.assertEqual(
             to_sublime("cp1252"),
             "Western (Windows 1252)"
         )
+
+    def test_to_error(self):
+        with self.assertRaises(ValueError):
+            to_sublime("Nonexistent")


### PR DESCRIPTION
The docs for `from_sublime` and `to_sublime` do not specify failure behavior. Depending on the circumstances, they would either return `None` or raise `LookupError`. With this PR, the functions will raise `ValueError` if they can't do their jobs.