### PR TITLE
Allow mismatched labels in show_selection_panel.

### DIFF
--- a/st3/sublime_lib/show_selection_panel.py
+++ b/st3/sublime_lib/show_selection_panel.py
@@ -64,9 +64,6 @@ def show_selection_panel(
 
     :raise ValueError: if `selected` is given and the value is not in `items`.
 
-    :raise ValueError: if some labels are sequences but not others
-        or if labels are sequences of inconsistent length.
-
     :raise ValueError: if `flags` cannot be converted
         to :class:`sublime_lib.flags.QuickPanelOption`.
 
@@ -82,17 +79,15 @@ def show_selection_panel(
     elif len(items) != len(labels):
         raise ValueError("The lengths of `items` and `labels` must match.")
 
-    if any(map(is_sequence_not_str, labels)):
-        if not all(map(is_sequence_not_str, labels)):
-            raise ValueError("Labels must be all strings or all lists.")
+    def normalize_label(label):
+        if is_sequence_not_str(label):
+            return list(map(str, label))
+        else:
+            return [str(label)]
 
-        if len(set(map(len, labels))) != 1:
-            raise ValueError(
-                "If labels are lists, they must all have the same number of elements.")
-
-        labels = list(map(lambda label: list(map(str, label)), labels))
-    else:
-        labels = list(map(str, labels))
+    labels = list(map(normalize_label, labels))
+    max_len = max(map(len, labels))
+    labels = [rows + [''] * (max_len - len(rows)) for rows in labels]
 
     def on_done(index):
         if index == -1:

--- a/tests/test_selection_panel.py
+++ b/tests/test_selection_panel.py
@@ -76,7 +76,7 @@ class TestSelectionPanel(TestCase):
 
         assert_called_once_with_partial(
             window.show_quick_panel,
-            items=['10', '20', '30'],
+            items=[['10'], ['20'], ['30']],
         )
 
     def test_multiline_type_coercion(self):
@@ -100,39 +100,45 @@ class TestSelectionPanel(TestCase):
         )
 
     def test_empty_items_error(self):
-        self.assertRaises(
-            ValueError,
-            show_selection_panel,
-            WindowMock(),
-            items=[]
-        )
+        with self.assertRaises(ValueError):
+            show_selection_panel(
+                WindowMock(),
+                items=[]
+            )
 
-    def test_mixed_label_types_error(self):
-        self.assertRaises(
-            ValueError,
-            show_selection_panel,
-            WindowMock(),
+    def test_mixed_label_types(self):
+        window = WindowMock()
+        show_selection_panel(
+            window=window,
             items=['a', 'b'],
             labels=[['a'], 'b']
         )
 
-    def test_mixed_label_lengths_error(self):
-        self.assertRaises(
-            ValueError,
-            show_selection_panel,
-            WindowMock(),
+        assert_called_once_with_partial(
+            window.show_quick_panel,
+            items=[['a'], ['b']],
+        )
+
+    def test_mixed_label_lengths(self):
+        window = WindowMock()
+        show_selection_panel(
+            window=window,
             items=['a', 'b'],
             labels=[['a'], ['b', 'c']]
         )
 
-    def test_item_labels_lengths_error(self):
-        self.assertRaises(
-            ValueError,
-            show_selection_panel,
-            WindowMock(),
-            items=['a', 'b', 'c'],
-            labels=['x', 'y']
+        assert_called_once_with_partial(
+            window.show_quick_panel,
+            items=[['a', ''], ['b', 'c']],
         )
+
+    def test_item_labels_lengths_error(self):
+        with self.assertRaises(ValueError):
+            show_selection_panel(
+                WindowMock(),
+                items=['a', 'b', 'c'],
+                labels=['x', 'y']
+            )
 
     def test_selected(self):
         on_select = MagicMock()
@@ -230,7 +236,7 @@ class TestSelectionPanel(TestCase):
 
         assert_called_once_with_partial(
             window.show_quick_panel,
-            items=['a', 'b', 'c'],
+            items=[['a'], ['b'], ['c']],
         )
 
     def test_labels_list(self):
@@ -248,7 +254,7 @@ class TestSelectionPanel(TestCase):
 
         assert_called_once_with_partial(
             window.show_quick_panel,
-            items=['a', 'b', 'c'],
+            items=[['a'], ['b'], ['c']],
         )
 
     def test_no_selected(self):


### PR DESCRIPTION
`show_selection_panel` will always pass a list of lists to `window.show_quick_panel` and will pad it with empty strings as necessary. If a future version of Sublime handles variable numbers of rows, we can case out the functionality.

Also modified some selection panel tests to use `with self.assertRaises()`.