### PR TITLE
Implemented missing flags from sublime_plugin.

### DIFF
--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -117,6 +117,7 @@ pre {
     border: 1px solid #33333333;
     border-radius: 2px;
     padding: 0.25rem;
+    font-size: 13px;
 }
 
 div.footer {

--- a/st3/sublime_lib/flags.py
+++ b/st3/sublime_lib/flags.py
@@ -173,3 +173,42 @@ class QuickPanelOption(IntFlag, metaclass=ExtensibleConstructorMeta):
     """
     MONOSPACE_FONT = sublime.MONOSPACE_FONT
     KEEP_OPEN_ON_FOCUS_LOST = sublime.KEEP_OPEN_ON_FOCUS_LOST
+
+
+@autodoc('HOVER')
+@construct_from_name
+class HoverLocation(IntEnum):
+    """
+    An :class:`~enum.IntEnum` for use with
+    :func:`sublime_plugin.EventListener.on_hover`.
+    """
+    TEXT = sublime.HOVER_TEXT
+    GUTTER = sublime.HOVER_GUTTER
+    MARGIN = sublime.HOVER_MARGIN
+
+
+@autodoc('OP')
+@construct_from_name
+class QueryContextOperator(IntEnum):
+    """
+    An :class:`~enum.IntEnum` for use with
+    :func:`sublime_plugin.EventListener.on_query_context`.
+    """
+    EQUAL = sublime.OP_EQUAL
+    NOT_EQUAL = sublime.OP_NOT_EQUAL
+    REGEX_MATCH = sublime.OP_REGEX_MATCH
+    NOT_REGEX_MATCH = sublime.OP_NOT_REGEX_MATCH
+    REGEX_CONTAINS = sublime.OP_REGEX_CONTAINS
+    NOT_REGEX_CONTAINS = sublime.OP_NOT_REGEX_CONTAINS
+
+
+@autodoc()
+@construct_union
+@construct_from_name
+class CompletionOptions(IntFlag, metaclass=ExtensibleConstructorMeta):
+    """
+    An :class:`~enum.IntFlag` for use with
+    :func:`sublime_plugin.EventListener.on_query_completions`.
+    """
+    INHIBIT_WORD_COMPLETIONS = sublime.INHIBIT_WORD_COMPLETIONS
+    INHIBIT_EXPLICIT_COMPLETIONS = sublime.INHIBIT_EXPLICIT_COMPLETIONS

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -45,3 +45,19 @@ class TestFlags(TestCase):
             flags.RegionOption(),
             flags.RegionOption(0)
         )
+
+    def test_query_context_operators(self):
+        ops = flags.QueryContextOperator
+
+        tests = [
+            ('EQUAL', 'x', 'x', 'y'),
+            ('REGEX_MATCH', 'aaa', r'a+', r'a'),
+            ('REGEX_CONTAINS', 'aaa', r'a', r'b'),
+        ]
+
+        for op, key, success, failure in tests:
+            self.assertTrue(ops(op).apply(key, success))
+            self.assertFalse(ops(op).apply(key, failure))
+
+            self.assertTrue(ops('NOT_' + op).apply(key, failure))
+            self.assertFalse(ops('NOT_' + op).apply(key, success))

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -24,12 +24,15 @@ class TestFlags(TestCase):
         self._test_enum(flags.DialogResult, 'DIALOG_')
         self._test_enum(flags.PointClass, 'CLASS_')
         self._test_enum(flags.PhantomLayout, 'LAYOUT_')
+        self._test_enum(flags.HoverLocation, 'HOVER_')
+        self._test_enum(flags.QueryContextOperator, 'OP_')
 
         self._test_enum(flags.FindOption)
         self._test_enum(flags.RegionOption)
         self._test_enum(flags.PopupOption)
         self._test_enum(flags.OpenFileOption)
         self._test_enum(flags.QuickPanelOption)
+        self._test_enum(flags.CompletionOptions)
 
     def test_from_strings(self):
         self.assertEqual(


### PR DESCRIPTION
It might also be handy to provide operator functionality for `QueryContextOperator`. Not sure of the best API for that.

EDIT: Maybe just `__call__`? E.g., `QueryContextOperator.EQUAL(1, 1)`.