### PR TITLE
Use pathlib dependency if available.

### DIFF
--- a/st3/sublime_lib/_compat/pathlib.py
+++ b/st3/sublime_lib/_compat/pathlib.py
@@ -1,0 +1,4 @@
+try:
+    from pathlib import *
+except ImportError:
+    from ..vendor.pathlib.pathlib import *

--- a/st3/sublime_lib/resource_path.py
+++ b/st3/sublime_lib/resource_path.py
@@ -4,7 +4,7 @@ import posixpath
 from collections import OrderedDict
 import os
 
-from .vendor.pathlib.pathlib import Path
+from ._compat.pathlib import Path
 from ._util.glob import get_glob_matcher
 
 

--- a/tests/test_resource_path.py
+++ b/tests/test_resource_path.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 
 from sublime_lib import ResourcePath
-from sublime_lib.vendor.pathlib.pathlib import Path
+from sublime_lib._compat.pathlib import Path
 
 from unittesting import DeferrableTestCase
 


### PR DESCRIPTION
This way, if another package is using the `pathlib` dependency, then they will be using the same types. This also simplifies type checking for packages or dependencies that use sublime_lib — mypy will use the same system pathlib for everything.

We can/should do the same for enum if this makes sense.