### PR TITLE
Add comprehensive type checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ docs/source/modules/
 *.doctree
 *.pickle
 modules.rst
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/source/modules/
 *.doctree
 *.pickle
 modules.rst
+.DS_Store

--- a/docs/source/extensions/prettify_special_methods.py
+++ b/docs/source/extensions/prettify_special_methods.py
@@ -75,7 +75,10 @@ SPECIAL_METHODS = {
         Text(' '),
         SphinxNodes.desc_name('', '', Text('=')),
         Text(' '),
-        emphasis('', parameters_node.children[1].astext()),
+        emphasis('', (
+            (parameters_node.children[1].astext())
+            if len(parameters_node.children) > 1 else ''
+        )),
     ),
     '__delitem__': lambda name_node, parameters_node: inline(
         '', '',

--- a/docs/source/mocks/sublime.py
+++ b/docs/source/mocks/sublime.py
@@ -3,8 +3,19 @@ from sphinx.ext.autodoc.importer import _MockObject
 import sys
 
 
+class MockType(_MockObject):
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return self.name
+
+
 class SublimeMock:
-    Region = _MockObject()
+    Region = MockType('sublime.Region')
+    View = MockType('sublime.View')
+    Window = MockType('sublime.Window')
+    Settings = MockType('sublime.Settings')
 
     def __getattr__(self, key):
         if key.isupper():

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 check_untyped_defs = True
+disallow_untyped_defs = True
 mypy_path =
     st3,
     stubs,

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,3 +7,6 @@ mypy_path =
 
 [mypy-sublime_lib.vendor.*]
 ignore_errors=True
+
+[mypy-sublime_lib._compat.typing_stubs]
+disallow_untyped_defs = False

--- a/st3/sublime_lib/_compat/typing.py
+++ b/st3/sublime_lib/_compat/typing.py
@@ -1,4 +1,4 @@
 try:
     from typing import *  # noqa: F401, F403
 except ImportError:
-    from .typing_stubs import *
+    from .typing_stubs import *  # type: ignore # noqa: F401, F403

--- a/st3/sublime_lib/_compat/typing_stubs.py
+++ b/st3/sublime_lib/_compat/typing_stubs.py
@@ -1,20 +1,338 @@
+def _MakeType(name):
+    return _TypeMeta(name, (Type,), {})
+
 
 class _TypeMeta(type):
-    def __getattr__(self, *args):
+    def __getitem__(self, args):
+        if not isinstance(args, tuple):
+            args = (args,)
+
         name = '{}[{}]'.format(
-            self.name,
-            ', '.join(arg.name for name in args)
+            str(self),
+            ', '.join(map(str, args))
         )
-        return _TypeMeta(name, (), {})
+        return _MakeType(name)
+
+    def __str__(self):
+        return self.__name__
+
+
+__all__ = [
+    # Super-special typing primitives.
+    'Any',
+    'Callable',
+    'ClassVar',
+    'Generic',
+    'Optional',
+    'Tuple',
+    'Type',
+    'TypeVar',
+    'Union',
+
+    # ABCs (from collections.abc).
+    'AbstractSet',  # collections.abc.Set.
+    'GenericMeta',  # subclass of abc.ABCMeta and a metaclass
+                    # for 'Generic' and ABCs below.
+    'ByteString',
+    'Container',
+    'ContextManager',
+    'Hashable',
+    'ItemsView',
+    'Iterable',
+    'Iterator',
+    'KeysView',
+    'Mapping',
+    'MappingView',
+    'MutableMapping',
+    'MutableSequence',
+    'MutableSet',
+    'Sequence',
+    'Sized',
+    'ValuesView',
+    # The following are added depending on presence
+    # of their non-generic counterparts in stdlib:
+    'Awaitable',
+    'AsyncIterator',
+    'AsyncIterable',
+    'Coroutine',
+    'Collection',
+    'AsyncGenerator',
+    # AsyncContextManager
+
+    # Structural checks, a.k.a. protocols.
+    'Reversible',
+    'SupportsAbs',
+    'SupportsBytes',
+    'SupportsComplex',
+    'SupportsFloat',
+    'SupportsInt',
+    'SupportsRound',
+
+    # Concrete collection types.
+    'Counter',
+    'Deque',
+    'Dict',
+    'DefaultDict',
+    'List',
+    'Set',
+    'FrozenSet',
+    'NamedTuple',  # Not really a type.
+    'Generator',
+
+    # One-off things.
+    'AnyStr',
+    'cast',
+    'get_type_hints',
+    'NewType',
+    'no_type_check',
+    'no_type_check_decorator',
+    'overload',
+    'Text',
+    'TYPE_CHECKING',
+
+    'ChainMap',
+    'NoReturn',
+]
+
+
+def NewType(name, typ):
+    return _MakeType(name)
+
+
+def TypeVar(name, *types):
+    return _MakeType(name)
+
+
+def cast(typ, val):
+    return val
+
+
+def get_type_hints(obj, globals=None, locals=None):
+    return {}
+
+
+def overload(function):
+    return function
+
+
+def no_type_check(function):
+    return function
+
+
+def no_type_check_decorator(function):
+    return function
+
+
+TYPE_CHECKING = False
+
 
 class Type(metaclass=_TypeMeta):
     pass
 
+
 class Any(Type):
     pass
+
 
 class Callable(Type):
     pass
 
+
+class ClassVar(Type):
+    pass
+
+
+class Generic(Type):
+    pass
+
+
 class Optional(Type):
+    pass
+
+
+class Tuple(Type):
+    pass
+
+
+class Union(Type):
+    pass
+
+
+class AbstractSet(Type):
+    pass
+
+
+class GenericMeta(Type):
+    pass
+
+
+class ByteString(Type):
+    pass
+
+
+class Container(Type):
+    pass
+
+
+class ContextManager(Type):
+    pass
+
+
+class Hashable(Type):
+    pass
+
+
+class ItemsView(Type):
+    pass
+
+
+class Iterable(Type):
+    pass
+
+
+class Iterator(Type):
+    pass
+
+
+class KeysView(Type):
+    pass
+
+
+class Mapping(Type):
+    pass
+
+
+class MappingView(Type):
+    pass
+
+
+class MutableMapping(Type):
+    pass
+
+
+class MutableSequence(Type):
+    pass
+
+
+class MutableSet(Type):
+    pass
+
+
+class Sequence(Type):
+    pass
+
+
+class Sized(Type):
+    pass
+
+
+class ValuesView(Type):
+    pass
+
+
+class Awaitable(Type):
+    pass
+
+
+class AsyncIterator(Type):
+    pass
+
+
+class AsyncIterable(Type):
+    pass
+
+
+class Coroutine(Type):
+    pass
+
+
+class Collection(Type):
+    pass
+
+
+class AsyncGenerator(Type):
+    pass
+
+
+class AsyncContextManage(Type):
+    pass
+
+
+class Reversible(Type):
+    pass
+
+
+class SupportsAbs(Type):
+    pass
+
+
+class SupportsBytes(Type):
+    pass
+
+
+class SupportsComplex(Type):
+    pass
+
+
+class SupportsFloat(Type):
+    pass
+
+
+class SupportsInt(Type):
+    pass
+
+
+class SupportsRound(Type):
+    pass
+
+
+class Counter(Type):
+    pass
+
+
+class Deque(Type):
+    pass
+
+
+class Dict(Type):
+    pass
+
+
+class DefaultDict(Type):
+    pass
+
+
+class List(Type):
+    pass
+
+
+class Set(Type):
+    pass
+
+
+class FrozenSet(Type):
+    pass
+
+
+class NamedTuple(Type):
+    pass
+
+
+class Generator(Type):
+    pass
+
+
+class AnyStr(Type):
+    pass
+
+
+class Text(Type):
+    pass
+
+
+class ChainMap(Type):
+    pass
+
+
+class NoReturn(Type):
     pass

--- a/st3/sublime_lib/_util/collections.py
+++ b/st3/sublime_lib/_util/collections.py
@@ -16,7 +16,10 @@ except ImportError:
 __all__ = ['projection', 'get_selector', 'isiterable', 'ismapping', 'is_sequence_not_str']
 
 
-def projection(d: 'Dict[str, _V]', keys: 'Union[Dict[str, str], Iterable[str]]') -> 'Dict[str, _V]':
+def projection(
+    d: 'Dict[str, _V]',
+    keys: 'Union[Dict[str, str], Iterable[str]]'
+) -> 'Dict[str, _V]':
     """
     Return a new :class:`dict` with keys of ``d`` restricted to values in ``keys``.
 

--- a/st3/sublime_lib/_util/collections.py
+++ b/st3/sublime_lib/_util/collections.py
@@ -1,10 +1,22 @@
 from collections.abc import Mapping, Sequence
 
+try:
+    from typing import Callable, Dict, Iterable, TypeVar, Union, overload
+
+    _V = TypeVar('_V')
+    _Result = TypeVar('_Result')
+    _Default = TypeVar('_Default')
+
+    _Value = Union[bool, int, float, str, list, dict, None]
+except ImportError:
+    pass
+    overload = lambda function: function
+
 
 __all__ = ['projection', 'get_selector', 'isiterable', 'ismapping', 'is_sequence_not_str']
 
 
-def projection(d, keys):
+def projection(d: 'Dict[str, _V]', keys: 'Union[Dict[str, str], Iterable[str]]') -> 'Dict[str, _V]':
     """
     Return a new :class:`dict` with keys of ``d`` restricted to values in ``keys``.
 
@@ -35,7 +47,31 @@ def projection(d, keys):
         }
 
 
-def get_selector(selector, default_value=None):
+@overload
+def get_selector(
+    selector: 'Callable[[Dict[str, _Value]], _Result]',
+    default_value: object = None
+) -> 'Callable[[Dict[str, _Value]], _Result]':
+    ...
+
+
+@overload  # noqa: F811
+def get_selector(
+    selector: str,
+    default_value: '_Default' = None
+) -> 'Callable[[Dict[str, _Value]], Union[_Value, _Default]]':
+    ...
+
+
+@overload  # noqa: F811
+def get_selector(
+    selector: 'Iterable[str]',
+    default_value: object = None
+) -> 'Callable[[Dict[str, _Value]], Dict[str, _Value]]':
+    ...
+
+
+def get_selector(selector, default_value=None):  # noqa: F811
     if callable(selector):
         return selector
     elif isinstance(selector, str):
@@ -48,17 +84,17 @@ def get_selector(selector, default_value=None):
         )
 
 
-def isiterable(obj):
+def isiterable(obj: object) -> bool:
     try:
-        iter(obj)
+        iter(obj)  # type: ignore
         return True
     except TypeError:
         return False
 
 
-def ismapping(obj):
+def ismapping(obj: object) -> bool:
     return isinstance(obj, Mapping)
 
 
-def is_sequence_not_str(obj):
+def is_sequence_not_str(obj: object) -> bool:
     return isinstance(obj, Sequence) and not isinstance(obj, str)

--- a/st3/sublime_lib/_util/collections.py
+++ b/st3/sublime_lib/_util/collections.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping, Sequence
 
-from .._compat.typing import Callable, Dict, Iterable, TypeVar, Union, overload
+from .._compat.typing import Callable, Dict, Iterable, TypeVar, Union
 
 
 _V = TypeVar('_V')
@@ -46,37 +46,13 @@ def projection(
         }
 
 
-@overload
-def get_selector(
-    selector: Callable[[Dict[str, _Value]], _Result],
-    default_value: object = None
-) -> Callable[[Dict[str, _Value]], _Result]:
-    ...
-
-
-@overload  # noqa: F811
-def get_selector(
-    selector: str,
-    default_value: _Default = None
-) -> Callable[[Dict[str, _Value]], Union[_Value, _Default]]:
-    ...
-
-
-@overload  # noqa: F811
-def get_selector(
-    selector: Iterable[str],
-    default_value: object = None
-) -> Callable[[Dict[str, _Value]], Dict[str, _Value]]:
-    ...
-
-
-def get_selector(selector, default_value=None):  # noqa: F811
+def get_selector(selector: object, default_value: object = None) -> Callable:  # noqa: F811
     if callable(selector):
         return selector
     elif isinstance(selector, str):
         return lambda this: this.get(selector, default_value)
     elif isiterable(selector):
-        return lambda this: projection(this, selector)
+        return lambda this: projection(this, selector)  # type: ignore
     else:
         raise TypeError(
             'The selector should be a function, string, or iterable of strings.'

--- a/st3/sublime_lib/_util/collections.py
+++ b/st3/sublime_lib/_util/collections.py
@@ -1,25 +1,21 @@
 from collections.abc import Mapping, Sequence
 
-try:
-    from typing import Callable, Dict, Iterable, TypeVar, Union, overload
+from .._compat.typing import Callable, Dict, Iterable, TypeVar, Union, overload
 
-    _V = TypeVar('_V')
-    _Result = TypeVar('_Result')
-    _Default = TypeVar('_Default')
 
-    _Value = Union[bool, int, float, str, list, dict, None]
-except ImportError:
-    pass
-    overload = lambda function: function
+_V = TypeVar('_V')
+_Result = TypeVar('_Result')
+_Default = TypeVar('_Default')
+_Value = Union[bool, int, float, str, list, dict, None]
 
 
 __all__ = ['projection', 'get_selector', 'isiterable', 'ismapping', 'is_sequence_not_str']
 
 
 def projection(
-    d: 'Dict[str, _V]',
-    keys: 'Union[Dict[str, str], Iterable[str]]'
-) -> 'Dict[str, _V]':
+    d: Dict[str, _V],
+    keys: Union[Dict[str, str], Iterable[str]]
+) -> Dict[str, _V]:
     """
     Return a new :class:`dict` with keys of ``d`` restricted to values in ``keys``.
 
@@ -52,25 +48,25 @@ def projection(
 
 @overload
 def get_selector(
-    selector: 'Callable[[Dict[str, _Value]], _Result]',
+    selector: Callable[[Dict[str, _Value]], _Result],
     default_value: object = None
-) -> 'Callable[[Dict[str, _Value]], _Result]':
+) -> Callable[[Dict[str, _Value]], _Result]:
     ...
 
 
 @overload  # noqa: F811
 def get_selector(
     selector: str,
-    default_value: '_Default' = None
-) -> 'Callable[[Dict[str, _Value]], Union[_Value, _Default]]':
+    default_value: _Default = None
+) -> Callable[[Dict[str, _Value]], Union[_Value, _Default]]:
     ...
 
 
 @overload  # noqa: F811
 def get_selector(
-    selector: 'Iterable[str]',
+    selector: Iterable[str],
     default_value: object = None
-) -> 'Callable[[Dict[str, _Value]], Dict[str, _Value]]':
+) -> Callable[[Dict[str, _Value]], Dict[str, _Value]]:
     ...
 
 

--- a/st3/sublime_lib/_util/enum.py
+++ b/st3/sublime_lib/_util/enum.py
@@ -1,27 +1,24 @@
 from functools import partial
 from ..vendor.python.enum import EnumMeta, Enum, Flag
 
-try:
-    from typing import Any, Callable, Optional
-except ImportError:
-    pass
+from .._compat.typing import Any, Callable, Optional
 
 
 __all__ = ['ExtensibleConstructorMeta', 'construct_with_alternatives', 'construct_union']
 
 
 class ExtensibleConstructorMeta(EnumMeta):
-    def __call__(cls, *args: 'Any', **kwargs: 'Any') -> 'Any':
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
         return cls.__new__(cls, *args, **kwargs)
 
 
 def extend_constructor(
-    constructor: 'Callable[..., Enum]'
-) -> 'Callable[[EnumMeta], EnumMeta]':
+    constructor: Callable[..., Enum]
+) -> Callable[[EnumMeta], EnumMeta]:
     def decorator(cls: EnumMeta) -> EnumMeta:
         next_constructor = partial(cls.__new__, cls)
 
-        def __new__(cls: EnumMeta, *args: 'Any', **kwargs: 'Any') -> Enum:
+        def __new__(cls: EnumMeta, *args: Any, **kwargs: Any) -> Enum:
             return constructor(next_constructor, cls, *args, **kwargs)
 
         cls.__new__ = __new__  # type: ignore
@@ -31,10 +28,10 @@ def extend_constructor(
 
 
 def construct_with_alternatives(
-    provider: 'Callable[..., Optional[Enum]]'
-) -> 'Callable[[EnumMeta], EnumMeta]':
-    def constructor(next_constructor: 'Callable[..., Enum]', cls: EnumMeta,
-                    *args: 'Any', **kwargs: 'Any') -> 'Enum':
+    provider: Callable[..., Optional[Enum]]
+) -> Callable[[EnumMeta], EnumMeta]:
+    def constructor(next_constructor: Callable[..., Enum], cls: EnumMeta,
+                    *args: Any, **kwargs: Any) -> Enum:
         try:
             return next_constructor(*args, **kwargs)
         except ValueError:
@@ -48,10 +45,10 @@ def construct_with_alternatives(
 
 
 def _construct_union(
-    next_constructor: 'Callable[[Any], Flag]',
+    next_constructor: Callable[[Any], Flag],
     cls: ExtensibleConstructorMeta,
-    *args: 'Any'
-) -> 'Any':
+    *args: Any
+) -> Any:
     if args:
         ret, *rest = iter(next_constructor(arg) for arg in args)
         for value in rest:

--- a/st3/sublime_lib/_util/enum.py
+++ b/st3/sublime_lib/_util/enum.py
@@ -1,30 +1,40 @@
 from functools import partial
-from ..vendor.python.enum import EnumMeta
+from ..vendor.python.enum import EnumMeta, Enum, Flag
+
+try:
+    from typing import Any, Callable, Optional
+except ImportError:
+    pass
 
 
 __all__ = ['ExtensibleConstructorMeta', 'construct_with_alternatives', 'construct_union']
 
 
 class ExtensibleConstructorMeta(EnumMeta):
-    def __call__(cls, *args, **kwargs):
+    def __call__(cls, *args: 'Any', **kwargs: 'Any') -> 'Any':
         return cls.__new__(cls, *args, **kwargs)
 
 
-def extend_constructor(constructor):
-    def decorator(cls):
+def extend_constructor(
+    constructor: 'Callable[..., Enum]'
+) -> 'Callable[[EnumMeta], EnumMeta]':
+    def decorator(cls: EnumMeta) -> EnumMeta:
         next_constructor = partial(cls.__new__, cls)
 
-        def __new__(cls, *args, **kwargs):
+        def __new__(cls: EnumMeta, *args: 'Any', **kwargs: 'Any') -> Enum:
             return constructor(next_constructor, cls, *args, **kwargs)
 
-        cls.__new__ = __new__
+        cls.__new__ = __new__  # type: ignore
         return cls
 
     return decorator
 
 
-def construct_with_alternatives(provider):
-    def constructor(next_constructor, cls, *args, **kwargs):
+def construct_with_alternatives(
+    provider: 'Callable[..., Optional[Enum]]'
+) -> 'Callable[[EnumMeta], EnumMeta]':
+    def constructor(next_constructor: 'Callable[..., Enum]', cls: EnumMeta,
+                    *args: 'Any', **kwargs: 'Any') -> 'Enum':
         try:
             return next_constructor(*args, **kwargs)
         except ValueError:
@@ -37,7 +47,11 @@ def construct_with_alternatives(provider):
     return extend_constructor(constructor)
 
 
-def _construct_union(next_constructor, cls, *args):
+def _construct_union(
+    next_constructor: 'Callable[[Any], Flag]',
+    cls: ExtensibleConstructorMeta,
+    *args: 'Any'
+) -> 'Any':
     if args:
         ret, *rest = iter(next_constructor(arg) for arg in args)
         for value in rest:

--- a/st3/sublime_lib/_util/glob.py
+++ b/st3/sublime_lib/_util/glob.py
@@ -1,6 +1,10 @@
 import re
 from functools import lru_cache
 
+try:
+    from typing import Callable
+except ImportError:
+    pass
 
 __all__ = ['get_glob_matcher']
 
@@ -14,7 +18,7 @@ GLOB_RE = re.compile(r"""(?x)(
 
 
 @lru_cache()
-def get_glob_matcher(pattern):
+def get_glob_matcher(pattern: str) -> 'Callable[[str], bool]':
     s = ''
     if pattern.startswith('/'):
         pattern = pattern[1:]

--- a/st3/sublime_lib/_util/glob.py
+++ b/st3/sublime_lib/_util/glob.py
@@ -1,10 +1,7 @@
 import re
 from functools import lru_cache
 
-try:
-    from typing import Callable
-except ImportError:
-    pass
+from .._compat.typing import Callable
 
 __all__ = ['get_glob_matcher']
 
@@ -18,7 +15,7 @@ GLOB_RE = re.compile(r"""(?x)(
 
 
 @lru_cache()
-def get_glob_matcher(pattern: str) -> 'Callable[[str], bool]':
+def get_glob_matcher(pattern: str) -> Callable[[str], bool]:
     s = ''
     if pattern.startswith('/'):
         pattern = pattern[1:]

--- a/st3/sublime_lib/_util/guard.py
+++ b/st3/sublime_lib/_util/guard.py
@@ -10,7 +10,9 @@ except ImportError:
     pass
 
 
-def define_guard(guard_fn: 'Callable[[_Self], Optional[ContextManager]]') -> 'Callable[[_WrappedType], _WrappedType]':
+def define_guard(
+    guard_fn: 'Callable[[_Self], Optional[ContextManager]]'
+)-> 'Callable[[_WrappedType], _WrappedType]':
     def decorator(wrapped: '_WrappedType') -> '_WrappedType':
         @wraps(wrapped)
         def wrapper_guards(self: '_Self', *args: 'Any', **kwargs: 'Any') -> '_R':

--- a/st3/sublime_lib/_util/guard.py
+++ b/st3/sublime_lib/_util/guard.py
@@ -1,12 +1,21 @@
 from functools import wraps
 
+try:
+    from typing import Any, Callable, ContextManager, Optional, TypeVar
 
-def define_guard(guard_fn):
-    def decorator(wrapped):
+    _Self = TypeVar('_Self')
+    _R = TypeVar('_R')
+    _WrappedType = Callable[..., _R]
+except ImportError:
+    pass
+
+
+def define_guard(guard_fn: 'Callable[[_Self], Optional[ContextManager]]') -> 'Callable[[_WrappedType], _WrappedType]':
+    def decorator(wrapped: '_WrappedType') -> '_WrappedType':
         @wraps(wrapped)
-        def wrapper_guards(self, *args, **kwargs):
+        def wrapper_guards(self: '_Self', *args: 'Any', **kwargs: 'Any') -> '_R':
             ret_val = guard_fn(self)
-            if hasattr(ret_val, '__enter__'):
+            if ret_val is not None:
                 with ret_val:
                     return wrapped(self, *args, **kwargs)
             else:

--- a/st3/sublime_lib/_util/guard.py
+++ b/st3/sublime_lib/_util/guard.py
@@ -1,21 +1,19 @@
 from functools import wraps
 
-try:
-    from typing import Any, Callable, ContextManager, Optional, TypeVar
+from .._compat.typing import Any, Callable, ContextManager, Optional, TypeVar
 
-    _Self = TypeVar('_Self')
-    _R = TypeVar('_R')
-    _WrappedType = Callable[..., _R]
-except ImportError:
-    pass
+
+_Self = TypeVar('_Self')
+_R = TypeVar('_R')
+_WrappedType = Callable[..., _R]
 
 
 def define_guard(
-    guard_fn: 'Callable[[_Self], Optional[ContextManager]]'
-)-> 'Callable[[_WrappedType], _WrappedType]':
-    def decorator(wrapped: '_WrappedType') -> '_WrappedType':
+    guard_fn: Callable[[_Self], Optional[ContextManager]]
+)-> Callable[[_WrappedType], _WrappedType]:
+    def decorator(wrapped: _WrappedType) -> _WrappedType:
         @wraps(wrapped)
-        def wrapper_guards(self: '_Self', *args: 'Any', **kwargs: 'Any') -> '_R':
+        def wrapper_guards(self: _Self, *args: Any, **kwargs: Any) -> _R:
             ret_val = guard_fn(self)
             if ret_val is not None:
                 with ret_val:

--- a/st3/sublime_lib/_util/named_value.py
+++ b/st3/sublime_lib/_util/named_value.py
@@ -1,6 +1,6 @@
 class NamedValue():
-    def __init__(self, name):
+    def __init__(self, name: str):
         self.name = name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.name

--- a/st3/sublime_lib/_util/simple_yaml.py
+++ b/st3/sublime_lib/_util/simple_yaml.py
@@ -1,17 +1,14 @@
 import sublime
 import re
 
-try:
-    from typing import Dict, Union
+from .._compat.typing import Dict, Union
 
-    YamlScalar = Union[str, bool, None]
-except ImportError:
-    pass
+YamlScalar = Union[str, bool, None]
 
 __all__ = ['parse_simple_top_level_keys']
 
 
-def parse_simple_top_level_keys(text: str) -> 'Dict[YamlScalar, YamlScalar]':
+def parse_simple_top_level_keys(text: str) -> Dict[YamlScalar, YamlScalar]:
     return {
         _parse_yaml_value(match.group(1)):
         _parse_yaml_value(match.group(2))
@@ -19,7 +16,7 @@ def parse_simple_top_level_keys(text: str) -> 'Dict[YamlScalar, YamlScalar]':
     }
 
 
-def _parse_yaml_value(value: str) -> 'YamlScalar':
+def _parse_yaml_value(value: str) -> YamlScalar:
     if value.startswith("'"):
         return value[1:-1].replace("''", "'")
     elif value.startswith('"'):

--- a/st3/sublime_lib/_util/simple_yaml.py
+++ b/st3/sublime_lib/_util/simple_yaml.py
@@ -1,11 +1,17 @@
 import sublime
 import re
 
+try:
+    from typing import Dict, Union
+
+    YamlScalar = Union[str, bool, None]
+except ImportError:
+    pass
 
 __all__ = ['parse_simple_top_level_keys']
 
 
-def parse_simple_top_level_keys(text):
+def parse_simple_top_level_keys(text: str) -> 'Dict[YamlScalar, YamlScalar]':
     return {
         _parse_yaml_value(match.group(1)):
         _parse_yaml_value(match.group(2))
@@ -13,7 +19,7 @@ def parse_simple_top_level_keys(text):
     }
 
 
-def _parse_yaml_value(value):
+def _parse_yaml_value(value: str) -> 'YamlScalar':
     if value.startswith("'"):
         return value[1:-1].replace("''", "'")
     elif value.startswith('"'):

--- a/st3/sublime_lib/encodings.py
+++ b/st3/sublime_lib/encodings.py
@@ -3,7 +3,7 @@ from codecs import lookup
 __all__ = ['from_sublime', 'to_sublime']
 
 
-def from_sublime(name):
+def from_sublime(name: str) -> str:
     """Translate `name` from a Sublime encoding name to a standard Python encoding name.
 
     :raise ValueError: if `name` is not a Sublime encoding.
@@ -20,7 +20,7 @@ def from_sublime(name):
         raise ValueError("Unknown Sublime encoding {!r}.".format(name)) from None
 
 
-def to_sublime(name):
+def to_sublime(name: str) -> str:
     """Translate `name` from a standard Python encoding name to a Sublime encoding name.
 
     :raise ValueError: if `name` is not a Python encoding.

--- a/st3/sublime_lib/flags.py
+++ b/st3/sublime_lib/flags.py
@@ -27,11 +27,15 @@ Descendants of :class:`IntFlag` accept zero or more arguments:
 
 import sublime
 
-from .vendor.python.enum import IntEnum, IntFlag
-from inspect import cleandoc
+from .vendor.python.enum import IntEnum, IntFlag, EnumMeta
+from inspect import getdoc, cleandoc
 
 from ._util.enum import ExtensibleConstructorMeta, construct_union, construct_with_alternatives
 
+try:
+    from typing import Callable, Optional
+except ImportError:
+    pass
 
 __all__ = [
     'DialogResult', 'PointClass', 'FindOption', 'RegionOption',
@@ -39,14 +43,14 @@ __all__ = [
 ]
 
 
-def autodoc(prefix=None):
+def autodoc(prefix: 'Optional[str]' = None) -> 'Callable[[EnumMeta], EnumMeta]':
     if prefix is None:
         prefix_str = ''
     else:
         prefix_str = prefix + '_'
 
-    def decorator(enum):
-        enum.__doc__ = cleandoc(enum.__doc__) + '\n\n' + '\n'.join([
+    def decorator(enum: EnumMeta) -> EnumMeta:
+        enum.__doc__ = getdoc(enum) + '\n\n' + '\n'.join([
             cleandoc("""
             .. py:attribute:: {name}
                 :annotation: = sublime.{pre}{name}

--- a/st3/sublime_lib/flags.py
+++ b/st3/sublime_lib/flags.py
@@ -35,10 +35,7 @@ import re
 
 from ._util.enum import ExtensibleConstructorMeta, construct_union, construct_with_alternatives
 
-try:
-    from typing import Callable, Optional
-except ImportError:
-    pass
+from ._compat.typing import Callable, Optional
 
 
 __all__ = [
@@ -48,7 +45,7 @@ __all__ = [
 ]
 
 
-def autodoc(prefix: 'Optional[str]' = None) -> 'Callable[[EnumMeta], EnumMeta]':
+def autodoc(prefix: Optional[str] = None) -> Callable[[EnumMeta], EnumMeta]:
     if prefix is None:
         prefix_str = ''
     else:
@@ -196,20 +193,20 @@ class HoverLocation(IntEnum):
     MARGIN = sublime.HOVER_MARGIN
 
 
-def regex_match(value, operand):
+def regex_match(value: str, operand: str) -> bool:
     expr = r'(?:{})\Z'.format(operand)
     return re.match(expr, value) is not None
 
 
-def not_regex_match(value, operand):
+def not_regex_match(value: str, operand: str) -> bool:
     return not regex_match(value, operand)
 
 
-def regex_contains(value, operand):
+def regex_contains(value: str, operand: str) -> bool:
     return re.search(operand, value) is not None
 
 
-def not_regex_contains(value, operand):
+def not_regex_contains(value: str, operand: str) -> bool:
     return not regex_contains(value, operand)
 
 
@@ -249,14 +246,16 @@ class QueryContextOperator(IntEnum):
     REGEX_CONTAINS = (sublime.OP_REGEX_CONTAINS, regex_contains)
     NOT_REGEX_CONTAINS = (sublime.OP_NOT_REGEX_CONTAINS, not_regex_contains)
 
-    def __new__(cls, value, operator):
+    # _apply_ = None  # type: Callable[[str, str], bool]
+
+    def __new__(cls, value: int, operator: Callable[[str, str], bool]) -> 'QueryContextOperator':
         obj = int.__new__(cls, value)  # type: ignore
         obj._value_ = value
         obj._apply_ = operator
         return obj
 
-    def apply(self, value, operand):
-        return self._apply_(value, operand)
+    def apply(self, value: str, operand: str) -> bool:
+        return self._apply_(value, operand)  # type: ignore
 
 
 @autodoc()

--- a/st3/sublime_lib/panel.py
+++ b/st3/sublime_lib/panel.py
@@ -4,10 +4,7 @@ from .view_stream import ViewStream
 from .view_utils import set_view_options, validate_view_options
 from ._util.guard import define_guard
 
-try:
-    from typing import Any
-except ImportError:
-    pass
+from ._compat.typing import Any
 
 __all__ = ['Panel', 'OutputPanel']
 
@@ -93,7 +90,7 @@ class OutputPanel(ViewStream, Panel):
         force_writes: bool = False,
         follow_cursor: bool = False,
         unlisted: bool = False,
-        **kwargs: 'Any'
+        **kwargs: Any
     ) -> 'OutputPanel':
         """Create a new output panel with the given `name` in the given `window`.
 

--- a/st3/sublime_lib/panel.py
+++ b/st3/sublime_lib/panel.py
@@ -1,6 +1,13 @@
+import sublime
+
 from .view_stream import ViewStream
 from .view_utils import set_view_options, validate_view_options
 from ._util.guard import define_guard
+
+try:
+    from typing import Any
+except ImportError:
+    pass
 
 __all__ = ['Panel', 'OutputPanel']
 
@@ -19,21 +26,21 @@ class Panel():
         The name of the panel as it is listed in :meth:`sublime.Window.panels()`.
     """
 
-    def __init__(self, window, panel_name):
+    def __init__(self, window: sublime.Window, panel_name: str):
         self.window = window
         self.panel_name = panel_name
 
         self._checkExists()
 
-    def _checkExists(self):
+    def _checkExists(self) -> None:
         if not self.exists():
             raise ValueError("Panel {} does not exist.".format(self.panel_name))
 
     @define_guard
-    def guard_exists(self):
+    def guard_exists(self) -> None:
         self._checkExists()
 
-    def exists(self):
+    def exists(self) -> bool:
         """Return ``True`` if the panel exists, or ``False`` otherwise.
 
         This implementation checks :meth:`sublime.Window.panels()`,
@@ -42,22 +49,22 @@ class Panel():
         return self.panel_name in self.window.panels()
 
     @guard_exists
-    def is_visible(self):
+    def is_visible(self) -> bool:
         """Return ``True`` if the panel is currently visible."""
         return self.window.active_panel() == self.panel_name
 
     @guard_exists
-    def show(self):
+    def show(self) -> None:
         """Show the panel, hiding any other visible panel."""
         self.window.run_command("show_panel", {"panel": self.panel_name})
 
     @guard_exists
-    def hide(self):
+    def hide(self) -> None:
         """Hide the panel."""
         self.window.run_command("hide_panel", {"panel": self.panel_name})
 
     @guard_exists
-    def toggle_visibility(self):
+    def toggle_visibility(self) -> None:
         """If the panel is visible, hide it; otherwise, show it."""
         if self.is_visible():
             self.hide()
@@ -75,12 +82,14 @@ class OutputPanel(ViewStream, Panel):
     @classmethod
     def create(
         cls,
-        window, name, *,
-        force_writes=False,
-        follow_cursor=False,
-        unlisted=False,
-        **kwargs
-    ):
+        window: sublime.Window,
+        name: str,
+        *,
+        force_writes: bool = False,
+        follow_cursor: bool = False,
+        unlisted: bool = False,
+        **kwargs: 'Any'
+    ) -> 'OutputPanel':
         """Create a new output panel with the given `name` in the given `window`.
 
         If `kwargs` are given,
@@ -95,9 +104,12 @@ class OutputPanel(ViewStream, Panel):
         return cls(window, name, force_writes=force_writes, follow_cursor=follow_cursor)
 
     def __init__(
-        self, window, name, *,
-        force_writes=False,
-        follow_cursor=False
+        self,
+        window: sublime.Window,
+        name: str,
+        *,
+        force_writes: bool = False,
+        follow_cursor: bool = False
     ):
         view = window.find_output_panel(name)
         if view is None:
@@ -109,7 +121,7 @@ class OutputPanel(ViewStream, Panel):
         self.name = name
 
     @property
-    def full_name(self):
+    def full_name(self) -> str:
         """The output panel name, beginning with ``'output.'``.
 
         Generally, API methods specific to output panels will use :attr:`name`,
@@ -117,7 +129,7 @@ class OutputPanel(ViewStream, Panel):
         """
         return self.panel_name
 
-    def exists(self):
+    def exists(self) -> bool:
         """Return ``True`` if the panel exists, or ``False`` otherwise.
 
         This implementation checks that the encapsulated :class:`~sublime.View` is valid,
@@ -125,6 +137,6 @@ class OutputPanel(ViewStream, Panel):
         """
         return self.view.is_valid()
 
-    def destroy(self):
+    def destroy(self) -> None:
         """Destroy the output panel."""
         self.window.destroy_output_panel(self.name)

--- a/st3/sublime_lib/resource_path.py
+++ b/st3/sublime_lib/resource_path.py
@@ -8,22 +8,19 @@ from abc import ABCMeta, abstractmethod
 from ._compat.pathlib import Path
 from ._util.glob import get_glob_matcher
 
-try:
-    from typing import Dict, List, Optional, Tuple
-except ImportError:
-    pass
+from ._compat.typing import List, Optional, Tuple, Iterable, Union
 
 __all__ = ['ResourcePath']
 
 
-def _abs_parts(path):
+def _abs_parts(path: Path) -> Tuple[str, ...]:
     if path.root:
         return (path.drive, path.root) + path.parts[1:]
     else:
         return path.parts
 
 
-def _file_relative_to(path, base):
+def _file_relative_to(path: Path, base: Path) -> Optional[Tuple[str, ...]]:
     """
     Like Path.relative_to, except:
 
@@ -37,7 +34,7 @@ def _file_relative_to(path, base):
     base_parts = _abs_parts(base)
 
     n = len(base_parts)
-    cf = path._flavour.casefold_parts
+    cf = path._flavour.casefold_parts  # type: ignore
 
     if n == 0:
         compare = (path.root or path.drive)
@@ -54,11 +51,11 @@ class ResourceRoot(metaclass=ABCMeta):
     """
     Represents a directory containing packages.
     """
-    def __init__(self, root, path):
+    def __init__(self, root: object, path: Union[Path, str]) -> None:
         self.resource_root = ResourcePath(root)
         self.file_root = Path(path)
 
-    def resource_to_file_path(self, resource_path):
+    def resource_to_file_path(self, resource_path: object) -> Path:
         """
         Given a :class:`ResourcePath`,
         return the corresponding :class:`Path` within this resource root.
@@ -73,7 +70,7 @@ class ResourceRoot(metaclass=ABCMeta):
         else:
             return self._package_file_path(*parts)
 
-    def file_to_resource_path(self, file_path):
+    def file_to_resource_path(self, file_path: Union[Path, str]) -> Optional['ResourcePath']:
         """
         Given an absolute :class:`Path`,
         return the corresponging :class:`ResourcePath` within this resource root,
@@ -95,7 +92,7 @@ class ResourceRoot(metaclass=ABCMeta):
             return self._package_resource_path(*parts)
 
     @abstractmethod
-    def _package_file_path(self, package, *parts):
+    def _package_file_path(self, package: str, *parts: str) -> Path:
         """
         Given a package name and zero or more path segments,
         return the corresponding :class:`Path` within this resource root.
@@ -103,7 +100,7 @@ class ResourceRoot(metaclass=ABCMeta):
         ...
 
     @abstractmethod
-    def _package_resource_path(self, package, *parts):
+    def _package_resource_path(self, package: str, *parts: str) -> 'ResourcePath':
         """
         Given a package name and zero or more path segments,
         return the corresponding :class:`ResourcePath` within this resource root.
@@ -115,10 +112,10 @@ class DirectoryResourceRoot(ResourceRoot):
     """
     Represents a directory containing unzipped package directories.
     """
-    def _package_file_path(self, *parts):
+    def _package_file_path(self, *parts: str) -> Path:
         return self.file_root.joinpath(*parts)
 
-    def _package_resource_path(self, *parts):
+    def _package_resource_path(self, *parts: str) -> 'ResourcePath':
         return self.resource_root.joinpath(*parts)
 
 
@@ -126,25 +123,25 @@ class InstalledResourceRoot(ResourceRoot):
     """
     Represents a directory containing zipped sublime-package files.
     """
-    def _package_file_path(self, package, *rest):
+    def _package_file_path(self, package: str, *rest: str) -> Path:
         return self.file_root.joinpath(package + '.sublime-package', *rest)
 
-    def _package_resource_path(self, package, *rest):
+    def _package_resource_path(self, package: str, *rest: str) -> 'ResourcePath':
         package_path = (self.resource_root / package).remove_suffix('.sublime-package')
         return package_path.joinpath(*rest)
 
 
-def wrap_path(p):
+def wrap_path(p: Union[str, Path]) -> Path:
     if isinstance(p, Path):
         return p
     else:
         return Path(p)
 
 
-_ROOTS = None
+_ROOTS = None  # type: Optional[List[ResourceRoot]]
 
 
-def get_roots():
+def get_roots() -> List[ResourceRoot]:
     global _ROOTS
     if _ROOTS is None:
         _ROOTS = [
@@ -190,7 +187,7 @@ class ResourcePath():
     """
 
     @classmethod
-    def glob_resources(cls, pattern: str) -> 'List[ResourcePath]':
+    def glob_resources(cls, pattern: str) -> List['ResourcePath']:
         """
         Find all resources that match the given pattern
         and return them as :class:`ResourcePath` objects.
@@ -202,7 +199,7 @@ class ResourcePath():
         ]
 
     @classmethod
-    def from_file_path(cls, file_path: object) -> 'ResourcePath':
+    def from_file_path(cls, file_path: Union[Path, str]) -> 'ResourcePath':
         """
         Return a :class:`ResourcePath` corresponding to the given file path.
 
@@ -254,7 +251,7 @@ class ResourcePath():
         if self._parts == ():
             raise ValueError("Empty path.")
 
-    def _parse_segments(self, pathsegments):
+    def _parse_segments(self, pathsegments: Iterable[object]) -> Tuple[str, ...]:
         return tuple(
             part
             for segment in pathsegments if segment
@@ -277,7 +274,7 @@ class ResourcePath():
         return self.joinpath(other)
 
     @property
-    def parts(self) -> 'Tuple[str, ...]':
+    def parts(self) -> Tuple[str, ...]:
         """
         A tuple giving access to the path’s various components.
         """
@@ -294,7 +291,7 @@ class ResourcePath():
             return self.__class__(*self._parts[:-1])
 
     @property
-    def parents(self) -> 'Tuple[ResourcePath, ...]':
+    def parents(self) -> Tuple['ResourcePath', ...]:
         """
         An immutable sequence providing access to the path's logical ancestors.
         """
@@ -324,7 +321,7 @@ class ResourcePath():
             return ''
 
     @property
-    def suffixes(self) -> 'List[str]':
+    def suffixes(self) -> List[str]:
         """
         A list of the final component's suffixes, if any.
         """
@@ -354,7 +351,7 @@ class ResourcePath():
         return self._parts[0]
 
     @property
-    def package(self) -> 'Optional[str]':
+    def package(self) -> Optional[str]:
         """
         The name of the package the path is within,
         or ``None`` if the path is a root path.
@@ -380,7 +377,7 @@ class ResourcePath():
         """
         return self.__class__(self, *other)
 
-    def relative_to(self, *other: object) -> 'Tuple[str, ...]':
+    def relative_to(self, *other: object) -> Tuple[str, ...]:
         """
         Compute a tuple `parts` of path components such that ``self == other.joinpath(*parts)``.
 
@@ -416,7 +413,7 @@ class ResourcePath():
         return self.with_name(self.name + suffix)
 
     def remove_suffix(
-        self, suffix: 'Optional[str]' = None, *, must_remove: bool = True
+        self, suffix: Optional[str] = None, *, must_remove: bool = True
     ) -> 'ResourcePath':
         """
         Return a new path with the suffix removed.
@@ -523,7 +520,7 @@ class ResourcePath():
         except IOError as err:
             raise FileNotFoundError(str(self)) from err
 
-    def glob(self, pattern: str) -> 'List[ResourcePath]':
+    def glob(self, pattern: str) -> List['ResourcePath']:
         """
         Glob the given pattern at this path, returning all matching resources.
 
@@ -532,7 +529,7 @@ class ResourcePath():
         base = '/' + str(self) + '/' if self._parts else ''
         return ResourcePath.glob_resources(base + pattern)
 
-    def rglob(self, pattern: str) -> 'List[ResourcePath]':
+    def rglob(self, pattern: str) -> List['ResourcePath']:
         """
         Shorthand for ``path.glob('**/' + pattern)``.
 
@@ -545,7 +542,7 @@ class ResourcePath():
 
         return self.glob('**/' + pattern)
 
-    def children(self) -> 'List[ResourcePath]':
+    def children(self) -> List['ResourcePath']:
         """
         Return a list of paths that are direct children of this path
         and point to a resource at or beneath that path.
@@ -584,7 +581,7 @@ class ResourcePath():
         with open(str(target), mode + 'b') as file:
             file.write(data)
 
-    def copytree(self, target, exist_ok=False):
+    def copytree(self, target: Union[Path, str], exist_ok: bool = False) -> None:
         """
         Copy all resources beneath this path into a directory tree rooted at `target`.
 

--- a/st3/sublime_lib/settings_dict.py
+++ b/st3/sublime_lib/settings_dict.py
@@ -123,8 +123,7 @@ class SettingsDict():
         if key in self:
             return self[key]
         else:
-            # self[key] = default
-            self.__setitem__(key, default)
+            self[key] = default
             return default
 
     def update(

--- a/st3/sublime_lib/settings_dict.py
+++ b/st3/sublime_lib/settings_dict.py
@@ -2,10 +2,20 @@ import sublime
 
 from uuid import uuid4
 from functools import partial
+from collections.abc import Mapping
 
-from ._util.collections import get_selector, ismapping
+from ._util.collections import get_selector
 from ._util.named_value import NamedValue
 
+try:
+    from typing import (
+        Any, Callable, Iterable, NoReturn, TypeVar, Union
+    )
+
+    _Default = TypeVar('_Default')
+    Value = Union[bool, int, float, str, list, dict, None]
+except ImportError:
+    pass
 
 __all__ = ['SettingsDict', 'NamedSettingsDict']
 
@@ -37,14 +47,14 @@ class SettingsDict():
 
     NO_DEFAULT = _NO_DEFAULT
 
-    def __init__(self, settings):
+    def __init__(self, settings: sublime.Settings):
         self.settings = settings
 
-    def __iter__(self):
+    def __iter__(self) -> 'NoReturn':
         """Raise NotImplementedError."""
         raise NotImplementedError()
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> 'Value':
         """Return the setting named `key`.
 
         If a subclass of :class:`SettingsDict` defines a method :meth:`__missing__`
@@ -64,14 +74,14 @@ class SettingsDict():
         else:
             return self.__missing__(key)
 
-    def __missing__(self, key):
+    def __missing__(self, key: str) -> 'Value':
         raise KeyError(key)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: 'Value') -> None:
         """Set `self[key]` to `value`."""
         self.settings.set(key, value)
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: str) -> None:
         """Remove `self[key]` from `self`.
 
         :raise KeyError: if there us no setting with the given `key`.
@@ -81,18 +91,20 @@ class SettingsDict():
         else:
             raise KeyError(key)
 
-    def __contains__(self, item):
+    def __contains__(self, item: str) -> bool:
         """Return ``True`` if `self` has a setting named `key`, else ``False``."""
         return self.settings.has(item)
 
-    def get(self, key, default=None):
+    def get(self, key: str, default: '_Default' = None) -> 'Union[Value, _Default]':
         """Return the value for `key` if `key` is in the dictionary, or `default` otherwise.
 
         If `default` is not given, it defaults to ``None``,
         so that this method never raises :exc:`KeyError`."""
         return self.settings.get(key, default)
 
-    def pop(self, key, default=_NO_DEFAULT):
+    def pop(
+        self, key: str, default: 'Union[_Default, NamedValue]' = _NO_DEFAULT
+    ) -> 'Union[Value, _Default]':
         """Remove the setting `self[key]` and return its value or `default`.
 
         :raise KeyError: if `key` is not in the dictionary
@@ -108,18 +120,23 @@ class SettingsDict():
         elif default is _NO_DEFAULT:
             raise KeyError(key)
         else:
-            return default
+            return default  # type: ignore
 
-    def setdefault(self, key, default=None):
+    def setdefault(self, key: str, default: 'Value' = None) -> 'Value':
         """Set `self[key]` to `default` if it wasn't already defined and return `self[key]`.
         """
         if key in self:
             return self[key]
         else:
-            self[key] = default
+            # self[key] = default
+            self.__setitem__(key, default)
             return default
 
-    def update(self, other=[], **kwargs):
+    def update(
+        self,
+        other: 'Union[Mapping[str, Value], Iterable[Iterable[str]]]' = [],
+        **kwargs: 'Value'
+    ) -> None:
         """Update the dictionary with the key/value pairs from `other`,
         overwriting existing keys.
 
@@ -129,8 +146,8 @@ class SettingsDict():
         the dictionary is then updated with those key/value pairs:
         ``self.update(red=1, blue=2)``.
         """
-        if ismapping(other):
-            other = other.items()
+        if isinstance(other, Mapping):
+            other = other.items()  # type: ignore
 
         for key, value in other:
             self[key] = value
@@ -138,7 +155,9 @@ class SettingsDict():
         for key, value in kwargs.items():
             self[key] = value
 
-    def subscribe(self, selector, callback, default_value=None):
+    def subscribe(
+        self, selector: 'Any', callback: 'Callable', default_value: 'Any' = None
+    ) -> 'Callable[[], None]':
         """Register a callback to be invoked
         when the value derived from the settings object changes
         and return a function that when invoked will unregister the callback.
@@ -160,7 +179,7 @@ class SettingsDict():
 
         previous_value = selector_fn(self)
 
-        def onchange():
+        def onchange() -> None:
             nonlocal previous_value
             new_value = selector_fn(self)
 
@@ -177,12 +196,12 @@ class NamedSettingsDict(SettingsDict):
     """Wraps a :class:`sublime.Settings` object corresponding to a `sublime-settings` file."""
 
     @property
-    def file_name(self):
+    def file_name(self) -> str:
         """The name of the sublime-settings files
         associated with the :class:`NamedSettingsDict`."""
         return self.name + '.sublime-settings'
 
-    def __init__(self, name):
+    def __init__(self, name: str):
         """Return a new :class:`NamedSettingsDict` corresponding to the given name."""
 
         if name.endswith('.sublime-settings'):
@@ -192,6 +211,6 @@ class NamedSettingsDict(SettingsDict):
 
         super().__init__(sublime.load_settings(self.file_name))
 
-    def save(self):
+    def save(self) -> None:
         """Flush any in-memory changes to the :class:`NamedSettingsDict` to disk."""
         sublime.save_settings(self.file_name)

--- a/st3/sublime_lib/settings_dict.py
+++ b/st3/sublime_lib/settings_dict.py
@@ -7,15 +7,10 @@ from collections.abc import Mapping
 from ._util.collections import get_selector
 from ._util.named_value import NamedValue
 
-try:
-    from typing import (
-        Any, Callable, Iterable, NoReturn, TypeVar, Union
-    )
+from ._compat.typing import Any, Callable, Iterable, NoReturn, TypeVar, Union, Mapping as _Mapping
 
-    _Default = TypeVar('_Default')
-    Value = Union[bool, int, float, str, list, dict, None]
-except ImportError:
-    pass
+_Default = TypeVar('_Default')
+Value = Union[bool, int, float, str, list, dict, None]
 
 __all__ = ['SettingsDict', 'NamedSettingsDict']
 
@@ -50,11 +45,11 @@ class SettingsDict():
     def __init__(self, settings: sublime.Settings):
         self.settings = settings
 
-    def __iter__(self) -> 'NoReturn':
+    def __iter__(self) -> NoReturn:
         """Raise NotImplementedError."""
         raise NotImplementedError()
 
-    def __getitem__(self, key: str) -> 'Value':
+    def __getitem__(self, key: str) -> Value:
         """Return the setting named `key`.
 
         If a subclass of :class:`SettingsDict` defines a method :meth:`__missing__`
@@ -74,10 +69,10 @@ class SettingsDict():
         else:
             return self.__missing__(key)
 
-    def __missing__(self, key: str) -> 'Value':
+    def __missing__(self, key: str) -> Value:
         raise KeyError(key)
 
-    def __setitem__(self, key: str, value: 'Value') -> None:
+    def __setitem__(self, key: str, value: Value) -> None:
         """Set `self[key]` to `value`."""
         self.settings.set(key, value)
 
@@ -95,7 +90,7 @@ class SettingsDict():
         """Return ``True`` if `self` has a setting named `key`, else ``False``."""
         return self.settings.has(item)
 
-    def get(self, key: str, default: '_Default' = None) -> 'Union[Value, _Default]':
+    def get(self, key: str, default: _Default = None) -> Union[Value, _Default]:
         """Return the value for `key` if `key` is in the dictionary, or `default` otherwise.
 
         If `default` is not given, it defaults to ``None``,
@@ -103,8 +98,8 @@ class SettingsDict():
         return self.settings.get(key, default)
 
     def pop(
-        self, key: str, default: 'Union[_Default, NamedValue]' = _NO_DEFAULT
-    ) -> 'Union[Value, _Default]':
+        self, key: str, default: Union[_Default, NamedValue] = _NO_DEFAULT
+    ) -> Union[Value, _Default]:
         """Remove the setting `self[key]` and return its value or `default`.
 
         :raise KeyError: if `key` is not in the dictionary
@@ -122,7 +117,7 @@ class SettingsDict():
         else:
             return default  # type: ignore
 
-    def setdefault(self, key: str, default: 'Value' = None) -> 'Value':
+    def setdefault(self, key: str, default: Value = None) -> Value:
         """Set `self[key]` to `default` if it wasn't already defined and return `self[key]`.
         """
         if key in self:
@@ -134,8 +129,8 @@ class SettingsDict():
 
     def update(
         self,
-        other: 'Union[Mapping[str, Value], Iterable[Iterable[str]]]' = [],
-        **kwargs: 'Value'
+        other: Union[_Mapping[str, Value], Iterable[Iterable[str]]] = [],
+        **kwargs: Value
     ) -> None:
         """Update the dictionary with the key/value pairs from `other`,
         overwriting existing keys.
@@ -156,8 +151,8 @@ class SettingsDict():
             self[key] = value
 
     def subscribe(
-        self, selector: 'Any', callback: 'Callable', default_value: 'Any' = None
-    ) -> 'Callable[[], None]':
+        self, selector: Any, callback: Callable, default_value: Any = None
+    ) -> Callable[[], None]:
         """Register a callback to be invoked
         when the value derived from the settings object changes
         and return a function that when invoked will unregister the callback.

--- a/st3/sublime_lib/show_selection_panel.py
+++ b/st3/sublime_lib/show_selection_panel.py
@@ -5,12 +5,9 @@ from ._util.named_value import NamedValue
 from .flags import QuickPanelOption
 from collections.abc import Sequence
 
-try:
-    from typing import Any, Callable, List, Optional, TypeVar, Union
+from ._compat.typing import Any, Callable, List, Optional, TypeVar, Union, Sequence as _Sequence
 
-    _ItemType = TypeVar('_ItemType')
-except ImportError:
-    pass
+_ItemType = TypeVar('_ItemType')
 
 __all__ = ['show_selection_panel', 'NO_SELECTION']
 
@@ -20,14 +17,14 @@ NO_SELECTION = NamedValue('NO_SELECTION')
 
 def show_selection_panel(
     window: sublime.Window,
-    items: 'Sequence[_ItemType]',
+    items: _Sequence[_ItemType],
     *,
-    flags: 'Any' = 0,
-    labels: 'Union[Sequence[object], Callable[[_ItemType], object]]' = None,
-    selected: 'Union[NamedValue, _ItemType]' = NO_SELECTION,
-    on_select: 'Optional[Callable[[_ItemType], object]]' = None,
-    on_cancel: 'Optional[Callable[[], object]]' = None,
-    on_highlight: 'Optional[Callable[[_ItemType], object]]' = None
+    flags: Any = 0,
+    labels: Union[_Sequence[object], Callable[[_ItemType], object]] = None,
+    selected: Union[NamedValue, _ItemType] = NO_SELECTION,
+    on_select: Optional[Callable[[_ItemType], object]] = None,
+    on_cancel: Optional[Callable[[], object]] = None,
+    on_highlight: Optional[Callable[[_ItemType], object]] = None
 ) -> None:
     """Open a quick panel in the given window to select an item from a list.
 
@@ -94,7 +91,7 @@ def show_selection_panel(
     elif len(items) != len(labels):
         raise ValueError("The lengths of `items` and `labels` must match.")
 
-    def normalize_label(label: object) -> 'List[str]':
+    def normalize_label(label: object) -> List[str]:
         if isinstance(label, Sequence) and not isinstance(label, str):
             return list(map(str, label))
         else:

--- a/st3/sublime_lib/syntax.py
+++ b/st3/sublime_lib/syntax.py
@@ -4,10 +4,7 @@ import plistlib
 from ._util.simple_yaml import parse_simple_top_level_keys
 from .resource_path import ResourcePath
 
-try:
-    from typing import List
-except ImportError:
-    pass
+from ._compat.typing import List
 
 __all__ = ['list_syntaxes', 'get_syntax_for_scope']
 
@@ -59,7 +56,7 @@ def get_syntax_metadata(path: ResourcePath) -> SyntaxInfo:
     )
 
 
-def list_syntaxes() -> 'List[SyntaxInfo]':
+def list_syntaxes() -> List[SyntaxInfo]:
     """Return a list of all loaded syntax definitions.
 
     Each item is a :class:`namedtuple` with the following properties:

--- a/st3/sublime_lib/syntax.py
+++ b/st3/sublime_lib/syntax.py
@@ -4,6 +4,10 @@ import plistlib
 from ._util.simple_yaml import parse_simple_top_level_keys
 from .resource_path import ResourcePath
 
+try:
+    from typing import List
+except ImportError:
+    pass
 
 __all__ = ['list_syntaxes', 'get_syntax_for_scope']
 
@@ -12,7 +16,7 @@ SyntaxInfo = namedtuple('SyntaxInfo', ['path', 'name', 'scope', 'hidden'])
 SyntaxInfo.__new__.__defaults__ = (None, None, False)  # type: ignore
 
 
-def get_sublime_syntax_metadata(path):
+def get_sublime_syntax_metadata(path: ResourcePath) -> dict:
     yaml = parse_simple_top_level_keys(path.read_text())
     return {
         'name': yaml.get('name') or path.stem,
@@ -21,7 +25,7 @@ def get_sublime_syntax_metadata(path):
     }
 
 
-def get_tmlanguage_metadata(path):
+def get_tmlanguage_metadata(path: ResourcePath) -> dict:
     tree = plistlib.readPlistFromBytes(path.read_bytes())
 
     return {
@@ -31,7 +35,7 @@ def get_tmlanguage_metadata(path):
     }
 
 
-def get_hidden_tmlanguage_metadata(path):
+def get_hidden_tmlanguage_metadata(path: ResourcePath) -> dict:
     tree = plistlib.readPlistFromBytes(path.read_bytes())
 
     return {
@@ -48,14 +52,14 @@ SYNTAX_TYPES = {
 }
 
 
-def get_syntax_metadata(path):
+def get_syntax_metadata(path: ResourcePath) -> SyntaxInfo:
     return SyntaxInfo(
         path=str(path),
         **SYNTAX_TYPES[path.suffix](path)
     )
 
 
-def list_syntaxes():
+def list_syntaxes() -> 'List[SyntaxInfo]':
     """Return a list of all loaded syntax definitions.
 
     Each item is a :class:`namedtuple` with the following properties:
@@ -87,10 +91,13 @@ def list_syntaxes():
     ]
 
 
-def get_syntax_for_scope(scope):
+def get_syntax_for_scope(scope: str) -> str:
     """Returns the last syntax in load order that matches `scope`."""
-    return next((
-        syntax.path
-        for syntax in reversed(list_syntaxes())
-        if syntax.scope == scope
-    ), None)
+    try:
+        return next(
+            syntax.path
+            for syntax in reversed(list_syntaxes())
+            if syntax.scope == scope
+        )
+    except StopIteration:
+        raise ValueError("Cannot find syntax for scope {!r}.".format(scope)) from None

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -94,7 +94,7 @@ class ViewStream(TextIOBase):
     @guard_validity
     @guard_selection
     def readline(self, size: int = -1) -> str:
-        """Read and return one line from the stream. to a maximum of `size` characters.
+        """Read and return one line from the stream, to a maximum of `size` characters.
 
         If the stream is already at EOF, return an empty string.
         """
@@ -104,7 +104,7 @@ class ViewStream(TextIOBase):
         return self._read(begin, end, size)
 
     def _read(self, begin: int, end: int, size: int) -> str:
-        if size is not None and size >= 0:
+        if size >= 0:
             end = min(end, begin + size)
 
         self._seek(end)

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -81,7 +81,7 @@ class ViewStream(TextIOBase):
 
     @guard_validity
     @guard_selection
-    def read(self, size: int) -> str:
+    def read(self, size: int = -1) -> str:
         """Read and return at most `size` characters from the stream as a single :class:`str`.
 
         If `size` is negative or None, read until EOF.
@@ -94,7 +94,7 @@ class ViewStream(TextIOBase):
     @guard_validity
     @guard_selection
     def readline(self, size: int = -1) -> str:
-        """Read until newline or EOF and return a single :class:`str`.
+        """Read and return one line from the stream. to a maximum of `size` characters.
 
         If the stream is already at EOF, return an empty string.
         """

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -6,10 +6,7 @@ from io import SEEK_SET, SEEK_CUR, SEEK_END, TextIOBase
 
 from ._util.guard import define_guard
 
-try:
-    from typing import Any, Generator
-except ImportError:
-    pass
+from ._compat.typing import Any, Generator
 
 
 class ViewStream(TextIOBase):
@@ -39,7 +36,7 @@ class ViewStream(TextIOBase):
 
     @define_guard
     @contextmanager
-    def guard_read_only(self) -> 'Generator[Any, None, None]':
+    def guard_read_only(self) -> Generator[Any, None, None]:
         if self.view.is_read_only():
             if self.force_writes:
                 self.view.set_read_only(False)
@@ -52,7 +49,7 @@ class ViewStream(TextIOBase):
 
     @define_guard
     @contextmanager
-    def guard_auto_indent(self) -> 'Generator[Any, None, None]':
+    def guard_auto_indent(self) -> Generator[Any, None, None]:
         settings = self.view.settings()
         if settings.get('auto_indent'):
             settings.set('auto_indent', False)

--- a/st3/sublime_lib/view_stream.py
+++ b/st3/sublime_lib/view_stream.py
@@ -1,9 +1,15 @@
+import sublime
 from sublime import Region
 
 from contextlib import contextmanager
 from io import SEEK_SET, SEEK_CUR, SEEK_END, TextIOBase
 
 from ._util.guard import define_guard
+
+try:
+    from typing import Any, Generator
+except ImportError:
+    pass
 
 
 class ViewStream(TextIOBase):
@@ -33,7 +39,7 @@ class ViewStream(TextIOBase):
 
     @define_guard
     @contextmanager
-    def guard_read_only(self):
+    def guard_read_only(self) -> 'Generator[Any, None, None]':
         if self.view.is_read_only():
             if self.force_writes:
                 self.view.set_read_only(False)
@@ -46,7 +52,7 @@ class ViewStream(TextIOBase):
 
     @define_guard
     @contextmanager
-    def guard_auto_indent(self):
+    def guard_auto_indent(self) -> 'Generator[Any, None, None]':
         settings = self.view.settings()
         if settings.get('auto_indent'):
             settings.set('auto_indent', False)
@@ -56,12 +62,12 @@ class ViewStream(TextIOBase):
             yield
 
     @define_guard
-    def guard_validity(self):
+    def guard_validity(self) -> None:
         if not self.view.is_valid():
             raise ValueError("The underlying view is invalid.")
 
     @define_guard
-    def guard_selection(self):
+    def guard_selection(self) -> None:
         if len(self.view.sel()) == 0:
             raise ValueError("The underlying view has no selection.")
         elif len(self.view.sel()) > 1:
@@ -69,14 +75,16 @@ class ViewStream(TextIOBase):
         elif not self.view.sel()[0].empty():
             raise ValueError("The underlying view's selection is not empty.")
 
-    def __init__(self, view, *, force_writes=False, follow_cursor=False):
+    def __init__(
+        self, view: sublime.View, *, force_writes: bool = False, follow_cursor: bool = False
+    ):
         self.view = view
         self.force_writes = force_writes
         self.follow_cursor = follow_cursor
 
     @guard_validity
     @guard_selection
-    def read(self, size):
+    def read(self, size: int) -> str:
         """Read and return at most `size` characters from the stream as a single :class:`str`.
 
         If `size` is negative or None, read until EOF.
@@ -88,7 +96,7 @@ class ViewStream(TextIOBase):
 
     @guard_validity
     @guard_selection
-    def readline(self, size=-1):
+    def readline(self, size: int = -1) -> str:
         """Read until newline or EOF and return a single :class:`str`.
 
         If the stream is already at EOF, return an empty string.
@@ -98,7 +106,7 @@ class ViewStream(TextIOBase):
 
         return self._read(begin, end, size)
 
-    def _read(self, begin, end, size):
+    def _read(self, begin: int, end: int, size: int) -> str:
         if size is not None and size >= 0:
             end = min(end, begin + size)
 
@@ -109,7 +117,7 @@ class ViewStream(TextIOBase):
     @guard_selection
     @guard_read_only
     @guard_auto_indent
-    def write(self, s):
+    def write(self, s: str) -> int:
         """Insert the string `s` into the view immediately before the cursor
         and return the number of characters inserted.
 
@@ -122,16 +130,16 @@ class ViewStream(TextIOBase):
         self._maybe_show_cursor()
         return self.view.size() - old_size
 
-    def print(self, *objects, sep=' ', end='\n'):
+    def print(self, *objects: object, sep: str = ' ', end: str = '\n') -> None:
         """Shorthand for :func:`print()` passing this ViewStream as the `file` argument."""
-        print(*objects, file=self, sep=sep, end=end)
+        print(*objects, file=self, sep=sep, end=end)  # type: ignore
 
-    def flush(self):
+    def flush(self) -> None:
         """Do nothing. (The stream is not buffered.)"""
         pass
 
     @guard_validity
-    def seek(self, offset, whence=SEEK_SET):
+    def seek(self, offset: int, whence: int = SEEK_SET) -> int:
         """Move the cursor in the view and return the new offset.
 
         If `whence` is provided,
@@ -153,7 +161,7 @@ class ViewStream(TextIOBase):
         else:
             raise TypeError('Invalid value for argument "whence".')
 
-    def _seek(self, offset):
+    def _seek(self, offset: int) -> int:
         selection = self.view.sel()
         selection.clear()
         selection.add(Region(offset))
@@ -161,41 +169,41 @@ class ViewStream(TextIOBase):
         return self._tell()
 
     @guard_validity
-    def seek_start(self):
+    def seek_start(self) -> None:
         """Move the cursor in the view to before the first character."""
         self._seek(0)
 
     @guard_validity
-    def seek_end(self):
+    def seek_end(self) -> None:
         """Move the cursor in the view to after the last character."""
         self._seek(self.view.size())
 
     @guard_validity
     @guard_selection
-    def tell(self):
+    def tell(self) -> int:
         """Return the character offset of the cursor."""
         return self._tell()
 
-    def _tell(self):
+    def _tell(self) -> int:
         return self.view.sel()[0].b
 
     @guard_validity
     @guard_selection
-    def show_cursor(self):
+    def show_cursor(self) -> None:
         """Scroll the view to show the position of the cursor."""
         self._show_cursor()
 
-    def _show_cursor(self):
+    def _show_cursor(self) -> None:
         self.view.show(self._tell())
 
-    def _maybe_show_cursor(self):
+    def _maybe_show_cursor(self) -> None:
         if self.follow_cursor:
             self._show_cursor()
 
     @guard_validity
     @guard_selection
     @guard_read_only
-    def clear(self):
+    def clear(self) -> None:
         """Erase all text in the view."""
         self.view.run_command('select_all')
         self.view.run_command('left_delete')

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -1,3 +1,5 @@
+import sublime
+
 import inspect
 
 from .vendor.python.enum import Enum
@@ -5,11 +7,16 @@ from ._util.enum import ExtensibleConstructorMeta, construct_with_alternatives
 from .syntax import get_syntax_for_scope
 from .encodings import to_sublime
 
+try:
+    from typing import Any, Optional
+except ImportError:
+    pass
+
 
 __all__ = ['LineEnding', 'new_view', 'close_view']
 
 
-def case_insensitive_value(cls, value):
+def case_insensitive_value(cls: ExtensibleConstructorMeta, value: str) -> 'Optional[Enum]':
     return next((
         member for name, member in cls.__members__.items()
         if name.lower() == value.lower()
@@ -39,7 +46,7 @@ class LineEnding(Enum, metaclass=ExtensibleConstructorMeta):
     CR = '\r'
 
 
-def new_view(window, **kwargs):
+def new_view(window: sublime.Window, **kwargs: 'Any') -> sublime.View:
     """Open a new view in the given `window`, returning the :class:`~sublime.View` object.
 
     This function takes many optional keyword arguments:
@@ -86,7 +93,7 @@ def new_view(window, **kwargs):
     return view
 
 
-def close_view(view, *, force=False):
+def close_view(view: sublime.View, *, force: bool = False) -> None:
     """Close the given view, discarding unsaved changes if `force` is ``True``.
 
     If the view is invalid (e.g. already closed), do nothing.
@@ -104,7 +111,7 @@ def close_view(view, *, force=False):
         raise ValueError('The view could not be closed.')
 
 
-def validate_view_options(options):
+def validate_view_options(options: 'Any') -> None:
     unknown = set(options) - VIEW_OPTIONS
     if unknown:
         raise ValueError('Unknown view options: %s.' % ', '.join(list(unknown)))
@@ -117,18 +124,19 @@ def validate_view_options(options):
 
 
 def set_view_options(
-    view, *,
-    name=None,
-    settings=None,
-    read_only=None,
-    scratch=None,
-    overwrite=None,
-    syntax=None,
-    scope=None,
-    encoding=None,
-    content=None,
-    line_endings=None
-):
+    view: sublime.View,
+    *,
+    name: 'Optional[str]' = None,
+    settings: 'Optional[dict]' = None,
+    read_only: 'Optional[bool]' = None,
+    scratch: 'Optional[bool]' = None,
+    overwrite: 'Optional[bool]' = None,
+    syntax: 'Optional[str]' = None,
+    scope: 'Optional[str]' = None,
+    encoding: 'Optional[str]' = None,
+    content: 'Optional[str]' = None,
+    line_endings: 'Optional[str]' = None
+) -> None:
     if name is not None:
         view.set_name(name)
 

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -7,7 +7,7 @@ from ._util.enum import ExtensibleConstructorMeta, construct_with_alternatives
 from .syntax import get_syntax_for_scope
 from .encodings import to_sublime
 
-from ._compat.typing import Any, Optional
+from ._compat.typing import Any, Optional, Mapping
 
 
 __all__ = ['LineEnding', 'new_view', 'close_view']
@@ -108,7 +108,7 @@ def close_view(view: sublime.View, *, force: bool = False) -> None:
         raise ValueError('The view could not be closed.')
 
 
-def validate_view_options(options: Any) -> None:
+def validate_view_options(options: Mapping[str, Any]) -> None:
     unknown = set(options) - VIEW_OPTIONS
     if unknown:
         raise ValueError('Unknown view options: %s.' % ', '.join(list(unknown)))

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -7,16 +7,13 @@ from ._util.enum import ExtensibleConstructorMeta, construct_with_alternatives
 from .syntax import get_syntax_for_scope
 from .encodings import to_sublime
 
-try:
-    from typing import Any, Optional
-except ImportError:
-    pass
+from ._compat.typing import Any, Optional
 
 
 __all__ = ['LineEnding', 'new_view', 'close_view']
 
 
-def case_insensitive_value(cls: ExtensibleConstructorMeta, value: str) -> 'Optional[Enum]':
+def case_insensitive_value(cls: ExtensibleConstructorMeta, value: str) -> Optional[Enum]:
     return next((
         member for name, member in cls.__members__.items()
         if name.lower() == value.lower()
@@ -46,7 +43,7 @@ class LineEnding(Enum, metaclass=ExtensibleConstructorMeta):
     CR = '\r'
 
 
-def new_view(window: sublime.Window, **kwargs: 'Any') -> sublime.View:
+def new_view(window: sublime.Window, **kwargs: Any) -> sublime.View:
     """Open a new view in the given `window`, returning the :class:`~sublime.View` object.
 
     This function takes many optional keyword arguments:
@@ -111,7 +108,7 @@ def close_view(view: sublime.View, *, force: bool = False) -> None:
         raise ValueError('The view could not be closed.')
 
 
-def validate_view_options(options: 'Any') -> None:
+def validate_view_options(options: Any) -> None:
     unknown = set(options) - VIEW_OPTIONS
     if unknown:
         raise ValueError('Unknown view options: %s.' % ', '.join(list(unknown)))
@@ -126,16 +123,16 @@ def validate_view_options(options: 'Any') -> None:
 def set_view_options(
     view: sublime.View,
     *,
-    name: 'Optional[str]' = None,
-    settings: 'Optional[dict]' = None,
-    read_only: 'Optional[bool]' = None,
-    scratch: 'Optional[bool]' = None,
-    overwrite: 'Optional[bool]' = None,
-    syntax: 'Optional[str]' = None,
-    scope: 'Optional[str]' = None,
-    encoding: 'Optional[str]' = None,
-    content: 'Optional[str]' = None,
-    line_endings: 'Optional[str]' = None
+    name: Optional[str] = None,
+    settings: Optional[dict] = None,
+    read_only: Optional[bool] = None,
+    scratch: Optional[bool] = None,
+    overwrite: Optional[bool] = None,
+    syntax: Optional[str] = None,
+    scope: Optional[str] = None,
+    encoding: Optional[str] = None,
+    content: Optional[str] = None,
+    line_endings: Optional[str] = None
 ) -> None:
     if name is not None:
         view.set_name(name)

--- a/st3/sublime_lib/window_utils.py
+++ b/st3/sublime_lib/window_utils.py
@@ -1,18 +1,22 @@
 import sublime
 
+try:
+    from typing import Optional
+except ImportError:
+    pass
 
 __all__ = ['new_window', 'close_window']
 
 
 def new_window(
     *,
-    menu_visible=None,
-    sidebar_visible=None,
-    tabs_visible=None,
-    minimap_visible=None,
-    status_bar_visible=None,
-    project_data=None
-):
+    menu_visible: 'Optional[bool]' = None,
+    sidebar_visible: 'Optional[bool]' = None,
+    tabs_visible: 'Optional[bool]' = None,
+    minimap_visible: 'Optional[bool]' = None,
+    status_bar_visible: 'Optional[bool]' = None,
+    project_data: 'Optional[dict]' = None
+) -> sublime.Window:
     """Open a new window, returning the :class:`~sublime.Window` object.
 
     This function takes many optional keyword arguments:
@@ -79,7 +83,7 @@ def new_window(
     return window
 
 
-def close_window(window, *, force=False):
+def close_window(window: sublime.Window, *, force: bool = False) -> None:
     """Close the given window, discarding unsaved changes if `force` is ``True``.
 
     :raise ValueError: if any view in the window has unsaved changes

--- a/st3/sublime_lib/window_utils.py
+++ b/st3/sublime_lib/window_utils.py
@@ -1,21 +1,18 @@
 import sublime
 
-try:
-    from typing import Optional
-except ImportError:
-    pass
+from ._compat.typing import Optional
 
 __all__ = ['new_window', 'close_window']
 
 
 def new_window(
     *,
-    menu_visible: 'Optional[bool]' = None,
-    sidebar_visible: 'Optional[bool]' = None,
-    tabs_visible: 'Optional[bool]' = None,
-    minimap_visible: 'Optional[bool]' = None,
-    status_bar_visible: 'Optional[bool]' = None,
-    project_data: 'Optional[dict]' = None
+    menu_visible: Optional[bool] = None,
+    sidebar_visible: Optional[bool] = None,
+    tabs_visible: Optional[bool] = None,
+    minimap_visible: Optional[bool] = None,
+    status_bar_visible: Optional[bool] = None,
+    project_data: Optional[dict] = None
 ) -> sublime.Window:
     """Open a new window, returning the :class:`~sublime.Window` object.
 

--- a/tests/test_view_stream.py
+++ b/tests/test_view_stream.py
@@ -95,6 +95,10 @@ class TestViewStream(DeferrableTestCase):
         text = self.stream.read(-1)
         self.assertEqual(text, "World!\nGoodbye, World!")
 
+        self.stream.seek(7)
+        text = self.stream.read()
+        self.assertEqual(text, "World!\nGoodbye, World!")
+
     def test_readline(self):
         self.stream.write("Hello, World!\nGoodbye, World!")
 

--- a/unittesting.json
+++ b/unittesting.json
@@ -1,3 +1,3 @@
 {
-    "deferred": true
+    "deferred": true,
 }

--- a/unittesting.json
+++ b/unittesting.json
@@ -1,3 +1,3 @@
 {
-    "deferred": true,
+    "deferred": true
 }


### PR DESCRIPTION
Includes a stub for the `typing` module. I tried vendoring the module, but it doesn't play well with 3.3, and we don't actually need it to do anything anyway.

Sphinx automatically includes type annotations in the docs. Sometimes the formatting is a mess. This should be addressed.