### PR TITLE
Fixed bug in glob matching.

### DIFF
--- a/st3/sublime_lib/_util/glob.py
+++ b/st3/sublime_lib/_util/glob.py
@@ -16,10 +16,11 @@ GLOB_RE = re.compile(r"""(?x)(
 
 @lru_cache()
 def get_glob_matcher(pattern: str) -> Callable[[str], bool]:
-    s = ''
+    s = r'\A'
     if pattern.startswith('/'):
         pattern = pattern[1:]
-        s += r'\A'
+    else:
+        pattern = '**/' + pattern
 
     for part in GLOB_RE.split(pattern):
         if part == '':

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -44,6 +44,7 @@ class TestGlob(TestCase):
             ],
             [
                 'Packages/Foo/bar/baz',
+                'FooFoo/bar',
             ]
         )
 

--- a/tests/test_pure_resource_path.py
+++ b/tests/test_pure_resource_path.py
@@ -202,6 +202,7 @@ class TestPureResourcePath(TestCase):
         self.assertFalse(path.match('Foo'))
         self.assertFalse(path.match('Packages/*/*/bar'))
         self.assertFalse(path.match('/Foo/bar'))
+        self.assertFalse(path.match('ar'))
 
     def test_joinpath(self):
         self.assertEqual(

--- a/tests/test_resource_path.py
+++ b/tests/test_resource_path.py
@@ -33,6 +33,18 @@ class TestResourcePath(DeferrableTestCase):
             ]
         )
 
+        self.assertEqual(
+            ResourcePath.glob_resources("ks27jArEz4"),
+            []
+        )
+
+        self.assertEqual(
+            ResourcePath.glob_resources("*ks27jArEz4"),
+            [
+                ResourcePath('Packages/sublime_lib/tests/uniquely_named_file_ks27jArEz4')
+            ]
+        )
+
     def test_from_file_path_packages(self):
         self.assertEqual(
             ResourcePath.from_file_path(Path(sublime.packages_path(), 'test_package')),


### PR DESCRIPTION
`ResourcePath.glob_resources()` should behave like `sublime.find_resources()`, except for the added glob functionality. Therefore, `ResourcePath.glob_resources('bar')` should not match a file named `foobar`.