### PR TITLE
Strip types in documentation.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -130,3 +130,6 @@ def setup(app):
     app.add_transform(PrettifySpecialMethods)
 
     app.connect('autodoc-skip-member', show_special_methods)
+
+    from strip_annotations import strip_annotations
+    app.connect('autodoc-process-signature', strip_annotations)

--- a/docs/source/extensions/strip_annotations.py
+++ b/docs/source/extensions/strip_annotations.py
@@ -1,0 +1,32 @@
+from sphinx.transforms import SphinxTransform
+from sphinx.util.inspect import Signature
+
+import inspect
+
+
+__all__ = ['strip_annotations']
+
+
+def strip_annotations(
+    app,
+    what: str,
+    name: str,
+    obj,
+    options,
+    signature,
+    return_annotation
+):
+    if what not in { 'function', 'method', 'class' }:
+        return
+
+    new_signature = Signature(obj)
+    new_signature.signature = new_signature.signature.replace(
+        return_annotation=inspect.Signature.empty,
+        parameters=[
+            param.replace(annotation=inspect.Parameter.empty)
+            for param in new_signature.signature.parameters.values()
+            if param.name != 'self'
+        ],
+    )
+
+    return new_signature.format_args(), None


### PR DESCRIPTION
Hopefully fix #118.

Strip the types from the generated signatures. I suspect that the types were causing #118.