### PR TITLE
Fix a MyPy issue.

### DIFF
--- a/st3/sublime_lib/flags.py
+++ b/st3/sublime_lib/flags.py
@@ -54,7 +54,7 @@ def autodoc(prefix: Optional[str] = None) -> Callable[[EnumMeta], EnumMeta]:
         prefix_str = prefix + '_'
 
     def decorator(enum: EnumMeta) -> EnumMeta:
-        enum.__doc__ = getdoc(enum) + '\n\n' + '\n'.join([
+        enum.__doc__ = (getdoc(enum) or '') + '\n\n' + '\n'.join([
             cleandoc("""
             .. py:attribute:: {name}
                 :annotation: = sublime.{pre}{name}


### PR DESCRIPTION
`getdoc` can return `None`, so even though we can be sure it won't, MyPy wants explicit reassurance.

MyPy is also reporting a number of errors related to the vendored enum module. Not sure how to fix that yet. See https://stackoverflow.com/questions/66282719/ignore-mypy-is-not-valid-as-a-type-error