### PR TITLE
Revert scratchness after closing view or window

### DIFF
--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -13,7 +13,6 @@ from ._compat.typing import Any, Optional, Mapping, Iterable, Generator
 
 __all__ = [
     'LineEnding', 'new_view', 'close_view',
-    '_clone_view', '_temporarily_scratch_unsaved_views',
 ]
 
 

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -13,7 +13,7 @@ from ._compat.typing import Any, Optional, Mapping, Iterable, Generator
 
 __all__ = [
     'LineEnding', 'new_view', 'close_view',
-    'clone_view', 'temporarily_scratch_unsaved_views',
+    '_clone_view', '_temporarily_scratch_unsaved_views',
 ]
 
 
@@ -95,7 +95,7 @@ def new_view(window: sublime.Window, **kwargs: Any) -> sublime.View:
 
 
 @contextmanager
-def temporarily_scratch_unsaved_views(
+def _temporarily_scratch_unsaved_views(
     unsaved_views: Iterable[sublime.View]
 ) -> Generator[None, None, None]:
     buffer_ids = {view.buffer_id() for view in unsaved_views}
@@ -114,7 +114,7 @@ def temporarily_scratch_unsaved_views(
         view.set_scratch(False)
 
 
-def clone_view(view: sublime.View) -> sublime.View:
+def _clone_view(view: sublime.View) -> sublime.View:
     window = view.window()
     if window is None:  # pragma: no cover
         raise ValueError("View has no window.")
@@ -142,7 +142,7 @@ def close_view(view: sublime.View, *, force: bool = False) -> None:
         if not force:
             raise ValueError('The view has unsaved changes.')
 
-        with temporarily_scratch_unsaved_views([view]):
+        with _temporarily_scratch_unsaved_views([view]):
             closed = view.close()
     else:
         closed = view.close()

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -102,16 +102,17 @@ def _temporarily_scratch_unsaved_views(
     for view in unsaved_views:
         view.set_scratch(True)
 
-    yield
-
-    clones = {
-        view.buffer_id(): view
-        for window in sublime.windows()
-        for view in window.views()
-        if view.buffer_id() in buffer_ids
-    }
-    for view in clones.values():
-        view.set_scratch(False)
+    try:
+        yield
+    finally:
+        clones = {
+            view.buffer_id(): view
+            for window in sublime.windows()
+            for view in window.views()
+            if view.buffer_id() in buffer_ids
+        }
+        for view in clones.values():
+            view.set_scratch(False)
 
 
 def _clone_view(view: sublime.View) -> sublime.View:

--- a/st3/sublime_lib/window_utils.py
+++ b/st3/sublime_lib/window_utils.py
@@ -2,7 +2,7 @@ import sublime
 
 from ._compat.typing import Optional
 
-from .view_utils import temporarily_scratch_unsaved_views
+from .view_utils import _temporarily_scratch_unsaved_views
 
 __all__ = ['new_window', 'close_window']
 
@@ -99,7 +99,7 @@ def close_window(window: sublime.Window, *, force: bool = False) -> None:
         if not force:
             raise ValueError('A view has unsaved changes.')
 
-        with temporarily_scratch_unsaved_views(unsaved):
+        with _temporarily_scratch_unsaved_views(unsaved):
             window.run_command('close_window')
     else:
         window.run_command('close_window')

--- a/st3/sublime_lib/window_utils.py
+++ b/st3/sublime_lib/window_utils.py
@@ -2,6 +2,8 @@ import sublime
 
 from ._compat.typing import Optional
 
+from .view_utils import temporarily_scratch_unsaved_views
+
 __all__ = ['new_window', 'close_window']
 
 
@@ -88,11 +90,16 @@ def close_window(window: sublime.Window, *, force: bool = False) -> None:
 
     .. versionadded:: 1.2
     """
-    for view in window.views():
-        if view.is_dirty() and not view.is_scratch():
-            if force:
-                view.set_scratch(True)
-            else:
-                raise ValueError('A view has unsaved changes.')
+    unsaved = [
+        view for view in window.views()
+        if view.is_dirty() and not view.is_scratch()
+    ]
 
-    window.run_command('close_window')
+    if unsaved:
+        if not force:
+            raise ValueError('A view has unsaved changes.')
+
+        with temporarily_scratch_unsaved_views(unsaved):
+            window.run_command('close_window')
+    else:
+        window.run_command('close_window')

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -1,5 +1,6 @@
 import sublime
 from sublime_lib import new_view, close_view, LineEnding
+from sublime_lib.view_utils import clone_view
 
 from unittest import TestCase
 
@@ -143,6 +144,16 @@ class TestViewUtils(TestCase):
 
         close_view(self.view, force=True)
         self.assertFalse(self.view.is_valid())
+
+    def test_close_unsaved_clone(self):
+        self.view = new_view(self.window, content="Hello, World!")
+
+        clone = clone_view(self.view)
+        close_view(clone, force=True)
+
+        self.assertFalse(clone.is_valid())
+        self.assertTrue(self.view.is_valid())
+        self.assertFalse(self.view.is_scratch())
 
     def test_close_closed_error(self):
         self.view = new_view(self.window)

--- a/tests/test_view_utils.py
+++ b/tests/test_view_utils.py
@@ -1,6 +1,6 @@
 import sublime
 from sublime_lib import new_view, close_view, LineEnding
-from sublime_lib.view_utils import clone_view
+from sublime_lib.view_utils import _clone_view
 
 from unittest import TestCase
 
@@ -148,7 +148,7 @@ class TestViewUtils(TestCase):
     def test_close_unsaved_clone(self):
         self.view = new_view(self.window, content="Hello, World!")
 
-        clone = clone_view(self.view)
+        clone = _clone_view(self.view)
         close_view(clone, force=True)
 
         self.assertFalse(clone.is_valid())

--- a/tests/test_window_utils.py
+++ b/tests/test_window_utils.py
@@ -8,6 +8,8 @@ from sublime_lib import new_window, close_window
 class TestNewWindow(DeferrableTestCase):
 
     def tearDown(self):
+        # We have to wait between opening and closing a window to avoid a crash.
+        # See https://github.com/sublimehq/sublime_text/issues/3960
         yield 100
         if getattr(self, '_window', None):
             close_window(self._window, force=True)

--- a/tests/test_window_utils.py
+++ b/tests/test_window_utils.py
@@ -8,6 +8,7 @@ from sublime_lib import new_window, close_window
 class TestNewWindow(DeferrableTestCase):
 
     def tearDown(self):
+        yield 100
         if getattr(self, '_window', None):
             close_window(self._window, force=True)
 
@@ -21,6 +22,7 @@ class TestNewWindow(DeferrableTestCase):
 
     def test_close_window(self):
         self._window = new_window()
+        yield 100
         close_window(self._window)
         yield 500
         self.assertFalse(self._window.is_valid())
@@ -30,6 +32,7 @@ class TestNewWindow(DeferrableTestCase):
 
         self._window.active_view().run_command('insert', {'characters': 'Hello, World!'})
 
+        yield 100
         with self.assertRaises(ValueError):
             close_window(self._window)
 


### PR DESCRIPTION
Fix #147.

Includes #148 so the window_util tests will run.

One case is not tested. If you have an unsaved view in one window and a clone of that view in the second window, and you `close_window()` the second window, the first view should not be scratch afterward. However, it doesn't look like it's possible to set that up using the Sublime API (https://github.com/sublimehq/sublime_text/issues/3965). I tested it by hand and It Works On My Machine™.

This PR does not expose `clone_view`.