### PR TITLE
Fix a bug when changing settings in a subscribe callback.

### DIFF
--- a/st3/sublime_lib/settings_dict.py
+++ b/st3/sublime_lib/settings_dict.py
@@ -181,15 +181,16 @@ class SettingsDict():
         """
         selector_fn = get_selector(selector)
 
-        previous_value = selector_fn(self)
+        saved_value = selector_fn(self)
 
         def onchange() -> None:
-            nonlocal previous_value
+            nonlocal saved_value
             new_value = selector_fn(self)
 
-            if new_value != previous_value:
+            if new_value != saved_value:
+                previous_value = saved_value
+                saved_value = new_value
                 callback(new_value, previous_value)
-                previous_value = new_value
 
         key = str(uuid4())
         self.settings.add_on_change(key, onchange)

--- a/tests/test_settings_dict.py
+++ b/tests/test_settings_dict.py
@@ -188,3 +188,17 @@ class TestSettingsDictSubscription(TestCase):
             'example_1': 10,
             'example_2': 2
         })
+
+    def test_settings_change_in_callback(self):
+        calls = []
+        def callback(new, old):
+            calls.append((new, old))
+            self.fancy['bar'] = True
+
+        self.fancy.subscribe('foo', callback)
+
+        self.fancy['foo'] = True
+
+        self.assertEqual(calls, [
+            (True, None)
+        ])

--- a/tests/test_settings_dict.py
+++ b/tests/test_settings_dict.py
@@ -191,6 +191,7 @@ class TestSettingsDictSubscription(TestCase):
 
     def test_settings_change_in_callback(self):
         calls = []
+
         def callback(new, old):
             calls.append((new, old))
             self.fancy['bar'] = True


### PR DESCRIPTION
Before this change, the saved value of a setting wasn't updated until after the callback was completed, so if you changed that settings object inside the callback, it would incorrectly detect that the first setting had changed again.