### PR TITLE
Fix the enum-related MyPy complaints.

### DIFF
--- a/st3/sublime_lib/_compat/enum.py
+++ b/st3/sublime_lib/_compat/enum.py
@@ -1,0 +1,4 @@
+try:
+    from enum import *  # noqa: F401, F403
+except ImportError:
+    from ..vendor.python.enum import *  # type: ignore # noqa: F401, F403

--- a/st3/sublime_lib/_compat/typing_stubs.py
+++ b/st3/sublime_lib/_compat/typing_stubs.py
@@ -99,7 +99,7 @@ def NewType(name, typ):
     return _MakeType(name)
 
 
-def TypeVar(name, *types):
+def TypeVar(name, *types, bound=None):
     return _MakeType(name)
 
 

--- a/st3/sublime_lib/_util/enum.py
+++ b/st3/sublime_lib/_util/enum.py
@@ -1,6 +1,6 @@
 from functools import partial
-from ..vendor.python.enum import EnumMeta, Enum, Flag
 
+from .._compat.enum import EnumMeta, Enum, Flag
 from .._compat.typing import Any, Callable, Optional
 
 

--- a/st3/sublime_lib/activity_indicator.py
+++ b/st3/sublime_lib/activity_indicator.py
@@ -126,7 +126,7 @@ class ActivityIndicator:
                 self._invocation_id += 1
         self._target.clear()
 
-    def _run(self, invocation_id) -> None:
+    def _run(self, invocation_id: int) -> None:
         with self._lock:
             if invocation_id == self._invocation_id:
                 self.tick()

--- a/st3/sublime_lib/flags.py
+++ b/st3/sublime_lib/flags.py
@@ -29,7 +29,7 @@ Descendants of :class:`IntFlag` accept zero or more arguments:
 
 import sublime
 
-from .vendor.python.enum import IntEnum, IntFlag, EnumMeta
+from ._compat.enum import IntEnum, IntFlag, EnumMeta
 from inspect import getdoc, cleandoc
 
 import operator
@@ -58,7 +58,7 @@ def autodoc(prefix: Optional[str] = None) -> Callable[[EnumMeta], EnumMeta]:
             cleandoc("""
             .. py:attribute:: {name}
                 :annotation: = sublime.{pre}{name}
-            """).format(name=item.name, pre=prefix_str) for item in enum
+            """).format(name=name, pre=prefix_str) for name in enum.__members__
         ])
 
         return enum

--- a/st3/sublime_lib/view_utils.py
+++ b/st3/sublime_lib/view_utils.py
@@ -3,12 +3,15 @@ import sublime
 import inspect
 from contextlib import contextmanager
 
-from .vendor.python.enum import Enum
+from ._compat.enum import Enum
 from ._util.enum import ExtensibleConstructorMeta, construct_with_alternatives
 from .syntax import get_syntax_for_scope
 from .encodings import to_sublime
 
-from ._compat.typing import Any, Optional, Mapping, Iterable, Generator
+from ._compat.typing import Any, Optional, Mapping, Iterable, Generator, Type, TypeVar
+
+
+EnumType = TypeVar('EnumType', bound=Enum)
 
 
 __all__ = [
@@ -16,7 +19,7 @@ __all__ = [
 ]
 
 
-def case_insensitive_value(cls: ExtensibleConstructorMeta, value: str) -> Optional[Enum]:
+def case_insensitive_value(cls: Type[EnumType], value: str) -> Optional[EnumType]:
     return next((
         member for name, member in cls.__members__.items()
         if name.lower() == value.lower()


### PR DESCRIPTION
Fix the complaints that the current version of MyPy is lodging against the enum stuff.

Also add the missing annotation in activity_indicator.py. There should be no remaining MyPy errors.

It will be nice to delete the `_compat` stuff for the first ST4-exclusive version.