### PR TITLE
Fix glob bug.

### DIFF
--- a/st3/sublime_lib/_util/glob.py
+++ b/st3/sublime_lib/_util/glob.py
@@ -28,7 +28,7 @@ def get_glob_matcher(pattern: str) -> Callable[[str], bool]:
             # Component must not be empty.
             expr_string += r'(?:[^/])+' + '/'
         elif component == '**':
-            expr_string += r'(?:(?:.*)(?:\Z|/))?'
+            expr_string += r'(?:.*(?:\Z|/))?'
         elif '**' in component:
             raise ValueError("Invalid pattern: '**' can only be an entire path component")
         else:

--- a/st3/sublime_lib/_util/glob.py
+++ b/st3/sublime_lib/_util/glob.py
@@ -7,8 +7,7 @@ __all__ = ['get_glob_matcher']
 
 
 GLOB_RE = re.compile(r"""(?x)(
-    (?:^|/) \*\* (?:$|/)
-    | (?<!\*)\*(?!\*)
+    \*
     | \?
     | \[ .*? \]
 )""")
@@ -16,27 +15,37 @@ GLOB_RE = re.compile(r"""(?x)(
 
 @lru_cache()
 def get_glob_matcher(pattern: str) -> Callable[[str], bool]:
-    s = r'\A'
     if pattern.startswith('/'):
         pattern = pattern[1:]
     else:
         pattern = '**/' + pattern
 
-    for part in GLOB_RE.split(pattern):
-        if part == '':
+    expr_string = r'\A'
+    for component in pattern.split('/'):
+        if component == '':
             pass
-        elif part.strip('/') == '**':
-            s += r'(?:^|/)(?:(?:.*)(?:$|/))?'
-        elif part == '*':
-            s += r'(?:[^/]*)'
-        elif part == '?':
-            s += r'(?:[^/])'
-        elif part[0] == '[':
-            s += part
-        elif '**' in part:
+        elif component == '*':
+            # Component must not be empty.
+            expr_string += r'(?:[^/])+' + '/'
+        elif component == '**':
+            expr_string += r'(?:(?:.*)(?:\Z|/))?'
+        elif '**' in component:
             raise ValueError("Invalid pattern: '**' can only be an entire path component")
         else:
-            s += re.escape(part)
+            for part in GLOB_RE.split(component):
+                if part == '':
+                    pass
+                elif part == '*':
+                    expr_string += r'(?:[^/])*'
+                elif part == '?':
+                    expr_string += r'(?:[^/])'
+                elif part[0] == '[':
+                    expr_string += part
+                else:
+                    expr_string += re.escape(part)
+            expr_string += '/'
 
-    expr = re.compile(s + r'\Z')
-    return lambda s: (expr.search(s) is not None)
+    expr_string = expr_string.rstrip('/') + r'\Z'
+    expr = re.compile(expr_string)
+
+    return lambda path: (expr.search(path) is not None)

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -115,6 +115,7 @@ class TestGlob(TestCase):
         self._test_matches(
             'Foo/**',
             [
+                'Packages/Foo/',
                 'Packages/Foo/bar',
                 'Packages/Foo/bar/baz',
             ],
@@ -152,6 +153,18 @@ class TestGlob(TestCase):
                 'Packages/Foo/bar',
             ],
             []
+        )
+
+        self._test_matches(
+            'Foo/**/*',
+            [
+                'Foo/bar',
+                'Foo/bar/baz',
+            ],
+            [
+                'Foo',
+                'Foo/',
+            ]
         )
 
     def test_placeholder(self):


### PR DESCRIPTION
For #134.

After much research and testing, I determined that the fundamental bug was that every pattern component except for `**` should match at least one character — so `/A*B/` should match `AB`, but `A/*` shouldn't match `A/`. This behavior should match other glob engines and resolve the linked bug.

This behavior varies slightly from `sublime.find_resources('*')`, which will find all resources (like `sublime.find_resources('')`.

It's probably bad news for other reasons if `sublime.find_resources()` returns directories, but at least now it shouldn't be bad news for us in particular.