### PR TITLE
Factor out weak_method.

### DIFF
--- a/st3/sublime_lib/_util/weak_method.py
+++ b/st3/sublime_lib/_util/weak_method.py
@@ -1,0 +1,21 @@
+import weakref
+
+from .._compat.typing import Callable, Any
+from types import MethodType
+
+
+__all__ = ['weak_method']
+
+
+def weak_method(method: Callable) -> Callable:
+    assert isinstance(method, MethodType)
+    self_ref = weakref.ref(method.__self__)
+    function_ref = weakref.ref(method.__func__)
+
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        self = self_ref()
+        function = function_ref()
+        if self is not None and function is not None:
+            return function(self, *args, **kwargs)
+
+    return wrapped

--- a/tests/test_weak_method.py
+++ b/tests/test_weak_method.py
@@ -1,0 +1,29 @@
+from sublime_lib._util.weak_method import weak_method
+
+from unittest import TestCase
+
+
+class TestWeakMethod(TestCase):
+
+    def test_weak(self):
+        count = 0
+
+        class TestObject:
+            def foo(self):
+                nonlocal count
+                count += 1
+
+        obj = TestObject()
+
+        obj.foo()
+        self.assertEqual(count, 1)
+
+        weak = weak_method(obj.foo)
+
+        weak()
+        self.assertEqual(count, 2)
+
+        del obj
+
+        weak()
+        self.assertEqual(count, 2)


### PR DESCRIPTION
Factor out weak_method so that it can be used elsewhere and add a basic test.

It might be useful to offer something like this as a utility function for users to pass callbacks to e.g. `sublime.set_timeout` without unnecessarily keeping things alive. 