### PR TITLE
New TemporaryPackage utility for tests.

### DIFF
--- a/st3/sublime_lib/_util/temporary_package.py
+++ b/st3/sublime_lib/_util/temporary_package.py
@@ -1,0 +1,30 @@
+import shutil
+from ..resource_path import ResourcePath
+
+
+__all__ = ['TemporaryPackage']
+
+
+class TemporaryPackage:
+    def __init__(self, package_name: str, resource_path: ResourcePath) -> None:
+        self.package_name = package_name
+        self.resource_path = resource_path
+
+    @property
+    def package_path(self) -> ResourcePath:
+        return ResourcePath("Packages") / self.package_name
+
+    def create(self) -> None:
+        shutil.copytree(
+            src=str(self.resource_path.file_path()),
+            dst=str(self.package_path.file_path()),
+        )
+
+    def destroy(self) -> None:
+        shutil.rmtree(
+            str(self.package_path.file_path()),
+            ignore_errors=True
+        )
+
+    def exists(self) -> bool:
+        return len(self.package_path.rglob('*')) > 0

--- a/tests/temporary_package.py
+++ b/tests/temporary_package.py
@@ -1,5 +1,5 @@
 import shutil
-from ..resource_path import ResourcePath
+from sublime_lib import ResourcePath
 
 
 __all__ = ['TemporaryPackage']

--- a/tests/test_resource_path.py
+++ b/tests/test_resource_path.py
@@ -3,7 +3,7 @@ import tempfile
 
 from sublime_lib import ResourcePath
 from sublime_lib._compat.pathlib import Path
-from sublime_lib._util.temporary_package import TemporaryPackage
+from .temporary_package import TemporaryPackage
 
 from unittesting import DeferrableTestCase
 

--- a/tests/test_resource_path.py
+++ b/tests/test_resource_path.py
@@ -1,9 +1,9 @@
 import sublime
-import shutil
 import tempfile
 
 from sublime_lib import ResourcePath
 from sublime_lib._compat.pathlib import Path
+from sublime_lib._util.temporary_package import TemporaryPackage
 
 from unittesting import DeferrableTestCase
 
@@ -11,18 +11,16 @@ from unittesting import DeferrableTestCase
 class TestResourcePath(DeferrableTestCase):
 
     def setUp(self):
-        shutil.copytree(
-            src=str(ResourcePath("Packages/sublime_lib/tests/test_package").file_path()),
-            dst=str(ResourcePath("Packages/test_package").file_path()),
+        self.temp = TemporaryPackage(
+            'test_package',
+            ResourcePath("Packages/sublime_lib/tests/test_package")
         )
+        self.temp.create()
 
-        yield ResourcePath("Packages/test_package/.test_package_exists").exists
+        yield self.temp.exists
 
     def tearDown(self):
-        shutil.rmtree(
-            str(ResourcePath("Packages/test_package").file_path()),
-            ignore_errors=True
-        )
+        self.temp.destroy()
 
     def test_glob_resources(self):
         self.assertEqual(


### PR DESCRIPTION
To abstract out the process of creating/cleaning up a temporary package. We'll use this for testing #136, at the very least.