### PR TITLE
Add SettingsListener.

### DIFF
--- a/st3/sublime_lib/__init__.py
+++ b/st3/sublime_lib/__init__.py
@@ -7,3 +7,6 @@ from .view_stream import ViewStream  # noqa: F401
 from .view_utils import new_view, close_view, LineEnding  # noqa: F401
 from .activity_indicator import ActivityIndicator  # noqa: F401
 from .window_utils import new_window, close_window  # noqa: F401
+from .settings_listener import (  # noqa: F401
+    GlobalSettingsListener, ViewSettingsListener, on_setting_changed
+)

--- a/st3/sublime_lib/settings_listener.py
+++ b/st3/sublime_lib/settings_listener.py
@@ -1,0 +1,85 @@
+import sublime
+import sublime_plugin
+
+from collections import namedtuple
+from ._util.weak_method import weak_method
+
+
+from ._compat.typing import Callable, Any, Iterator, Tuple, TypeVar, Union
+
+
+__all__ = ['GlobalSettingsListener', 'ViewSettingsListener', 'on_setting_changed']
+
+
+OnChangedOptions = namedtuple('OnChangedOptions', ('selector'))
+OPTIONS_ATTRIBUTE = '_sublime_lib_settings_listener_options'
+
+
+class BaseSettingsListener:
+    def _handlers(self) -> Iterator[Tuple[str, Callable, OnChangedOptions]]:
+        for name in dir(self):
+            value = getattr(self, name)
+            options = getattr(value, OPTIONS_ATTRIBUTE, None)
+
+            if not name.startswith('_') and options is not None:
+                yield name, value, options
+
+    def __init__(self, settings: sublime.Settings, *args: Any, **kwargs: Any) -> None:
+        # Don't complain that object.__init__ doesn't take any args
+        super().__init__(*args, **kwargs)  # type: ignore
+        self.settings = settings
+
+        self.settings.add_on_change(str(id(self)), weak_method(self._on_settings_changed))
+
+        self._last_known_values = {
+            name: options.selector(self.settings)
+            for name, _, options in self._handlers()
+        }
+
+    def __del__(self) -> None:
+        self.settings.clear_on_change(str(id(self)))
+
+    def _on_settings_changed(self) -> None:
+        for name, handler, options in self._handlers():
+            previous_value = self._last_known_values[name]
+            current_value = options.selector(self.settings)
+
+            if current_value != previous_value:
+                self._last_known_values[name] = current_value
+                handler(current_value, previous_value)
+
+
+class GlobalSettingsListener(BaseSettingsListener, sublime_plugin.EventListener):
+    SETTINGS_NAME = ''
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(sublime.load_settings(self.SETTINGS_NAME), *args, **kwargs)
+
+
+class ViewSettingsListener(BaseSettingsListener, sublime_plugin.ViewEventListener):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        view = args[0]
+        assert isinstance(view, sublime.View)
+        super().__init__(view.settings(), *args, **kwargs)
+
+
+Selected = TypeVar('Selected')
+OnChangeListener = Callable[[BaseSettingsListener, Selected, Selected], None]
+
+
+def on_setting_changed(
+    selector: Union[str, Callable[[sublime.Settings], Selected]]
+) -> Callable[[OnChangeListener], OnChangeListener]:
+    if callable(selector):
+        selector_function = selector
+    elif isinstance(selector, str):
+        selector_str = selector
+        selector_function = lambda settings: settings.get(selector_str)
+    else:
+        raise TypeError('Selector must be a string or function.')
+
+    def decorator(function: OnChangeListener) -> OnChangeListener:
+        setattr(function, OPTIONS_ATTRIBUTE, OnChangedOptions(selector_function))
+        return function
+
+    return decorator

--- a/tests/settings_listener_package/settings_listener_plugin.py
+++ b/tests/settings_listener_package/settings_listener_plugin.py
@@ -1,0 +1,20 @@
+from sublime_lib import ViewSettingsListener, GlobalSettingsListener, on_setting_changed
+
+
+__all__ = ['FooSettingListener', 'GlobalFooSettingListener']
+
+
+class FooSettingListener(ViewSettingsListener):
+    @on_setting_changed('foo')
+    def foo_changed(self, new_value: object, old_value: object):
+        changes = self.settings.get('changes', [])
+        self.settings.set('changes', changes + [[new_value, old_value]])
+        print('foo_changed', new_value, old_value, changes)
+
+
+class GlobalFooSettingListener(GlobalSettingsListener):
+    SETTINGS_NAME = 'Baz.sublime-settings'
+
+    @on_setting_changed('foobar')
+    def foo_changed(self, new_value: object, old_value: object):
+        print('foo_changed', new_value, old_value)

--- a/tests/test_settings_listener.py
+++ b/tests/test_settings_listener.py
@@ -1,0 +1,33 @@
+import sublime
+from sublime_lib import ResourcePath, new_view, close_view
+from .temporary_package import TemporaryPackage
+
+from unittesting import DeferrableTestCase
+
+
+class TestViewSettingsListener(DeferrableTestCase):
+    def setUp(self):
+        self.view = new_view(sublime.active_window())
+        self.temporary_package = TemporaryPackage(
+            'sublime_lib_settings_listener_test',
+            ResourcePath("Packages/sublime_lib/tests/settings_listener_package")
+        )
+        self.temporary_package.create()
+        yield self.temporary_package.exists
+
+    def tearDown(self):
+        self.temporary_package.destroy()
+        if getattr(self, 'view', None):
+            try:
+                close_view(self.view, force=True)
+            except ValueError:
+                pass
+
+    def test_view_listener(self):
+        self.view.settings().set('foo', 'A')
+        self.view.settings().set('foo', 'B')
+
+        self.assertEqual(self.view.settings().get('changes'), [
+            ['A', None],
+            ['B', 'A'],
+        ])


### PR DESCRIPTION
For #164.

Notes:

- Needs documentation, many more tests, more error handling.
- A couple of the types could be tightened up.
- `OnChangedOptions` is a named tuple so that we can easily support more arguments to `on_setting_changed`.
- One obvious idea is an `async` argument to `on_setting_changed`. Alternatively/additionally, we could have a separate `on_setting_changed_async` decorator.
- Instead of `SETTINGS_NAME = 'Foo'`, we could just have `settings = sublime.load_settings('Foo.sublime-settings')`. I think the former might be slightly less prone to user error.
- As you mentioned in the issue, it would be nice to have error handling if someone uses the `on_setting_changed` decorator outside a `BaseSettingsListener`. Haven't looked into implementation yet.
- If someone unintentionally exports `ViewSettingsListener` or `GlobalSettingsListener` from their plugin, Sublime will dutifully use them. This probably doesn't really matter, but we could special-case this if we want.
- Is there any reason to let users specify a custom key, rather than `str(id(self))`? I suspect not.
- Do we want a `WindowSettingsListener`? I also suspect not.
- Currently, `selector` only supports strings and functions, but we could just use `_util.collections.get_selector`.