### PR TITLE
Never use an existing enum module.

### DIFF
--- a/st3/sublime_lib/_compat/enum.py
+++ b/st3/sublime_lib/_compat/enum.py
@@ -1,4 +1,4 @@
-if False:
+if False:  # For MyPy only
     from enum import *  # noqa: F401, F403
 else:
     from ..vendor.python.enum import *  # type: ignore # noqa: F401, F403

--- a/st3/sublime_lib/_compat/enum.py
+++ b/st3/sublime_lib/_compat/enum.py
@@ -1,4 +1,4 @@
-try:
+if False:
     from enum import *  # noqa: F401, F403
-except ImportError:
+else:
     from ..vendor.python.enum import *  # type: ignore # noqa: F401, F403


### PR DESCRIPTION
See https://github.com/sublimelsp/LSP-typescript/issues/55.

In 1.5, we use an existing `enum` module if there is one. However, the `enum` dependency is a port of `enum34`, which does not support all of the features we need. This PR always uses the vendored `enum` module, but keeps the other import in unreachable code to keep MyPy happy.

If there are no issues, we'll want to push this out as 1.5.1 ASAP.