### PR TITLE
Never use an existing enum module. (#168)

### DIFF
--- a/st3/sublime_lib/_compat/enum.py
+++ b/st3/sublime_lib/_compat/enum.py
@@ -1,4 +1,4 @@
-try:
+if False:  # For MyPy only
     from enum import *  # noqa: F401, F403
-except ImportError:
+else:
     from ..vendor.python.enum import *  # type: ignore # noqa: F401, F403


### PR DESCRIPTION
See https://github.com/SublimeText/sublime_lib/pull/168.