### PR TITLE
Improve `define_guard` typing

### DIFF
--- a/sublime_lib/_util/enum.py
+++ b/sublime_lib/_util/enum.py
@@ -21,7 +21,7 @@ def extend_constructor(
         def __new__(cls: EnumMeta, *args: Any, **kwargs: Any) -> Enum:
             return constructor(next_constructor, cls, *args, **kwargs)
 
-        cls.__new__ = __new__  # type: ignore
+        cls.__new__ = __new__
         return cls
 
     return decorator

--- a/sublime_lib/_util/guard.py
+++ b/sublime_lib/_util/guard.py
@@ -13,7 +13,9 @@ if TYPE_CHECKING:
 def define_guard(
     guard_fn: Callable[[_Self], ContextManager[Any] | None]
 ) -> Callable[[Callable[Concatenate[_Self, _P], _T]], Callable[Concatenate[_Self, _P], _T]]:
-    def decorator(wrapped: Callable[Concatenate[_Self, _P], _T]) -> Callable[Concatenate[_Self, _P], _T]:
+    def decorator(
+        wrapped: Callable[Concatenate[_Self, _P], _T]
+    ) -> Callable[Concatenate[_Self, _P], _T]:
         @wraps(wrapped)
         def wrapper(self: _Self, /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
             ret_val = guard_fn(self)

--- a/sublime_lib/_util/guard.py
+++ b/sublime_lib/_util/guard.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 from functools import wraps
-from typing import Any, Callable, ContextManager, TypeVar
+from typing import TYPE_CHECKING
 
-
-_Self = TypeVar('_Self')
-_WrappedType = Callable[..., Any]
+if TYPE_CHECKING:
+    from typing import Any, Callable, ContextManager, TypeVar
+    from typing_extensions import ParamSpec, Concatenate
+    _Self = TypeVar('_Self')
+    _T = TypeVar('_T')
+    _P = ParamSpec('_P')
 
 
 def define_guard(
-    guard_fn: Callable[[_Self], ContextManager | None]
-) -> Callable[[_WrappedType], _WrappedType]:
-    def decorator(wrapped: _WrappedType) -> _WrappedType:
+    guard_fn: Callable[[_Self], ContextManager[Any] | None]
+) -> Callable[[Callable[Concatenate[_Self, _P], _T]], Callable[Concatenate[_Self, _P], _T]]:
+    def decorator(wrapped: Callable[Concatenate[_Self, _P], _T]) -> Callable[Concatenate[_Self, _P], _T]:
         @wraps(wrapped)
-        def wrapper_guards(self: _Self, *args: Any, **kwargs: Any) -> Any:
+        def wrapper(self: _Self, /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
             ret_val = guard_fn(self)
             if ret_val is not None:
                 with ret_val:
@@ -20,6 +23,6 @@ def define_guard(
             else:
                 return wrapped(self, *args, **kwargs)
 
-        return wrapper_guards
+        return wrapper
 
     return decorator

--- a/sublime_lib/panel.py
+++ b/sublime_lib/panel.py
@@ -10,6 +10,11 @@ from ._util.guard import define_guard
 __all__ = ['Panel', 'OutputPanel']
 
 
+@define_guard
+def guard_exists(panel: Panel) -> None:
+    panel._checkExists()
+
+
 class Panel():
     """An abstraction of a panel, such as the console or an output panel.
 
@@ -35,10 +40,6 @@ class Panel():
     def _checkExists(self) -> None:
         if not self.exists():
             raise ValueError(f"Panel {self.panel_name} does not exist.")
-
-    @define_guard
-    def guard_exists(self) -> None:
-        self._checkExists()
 
     def exists(self) -> bool:
         """Return ``True`` if the panel exists, or ``False`` otherwise.

--- a/sublime_lib/view_stream.py
+++ b/sublime_lib/view_stream.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 from collections.abc import Generator
 from contextlib import contextmanager
-from io import SEEK_SET, SEEK_CUR, SEEK_END, TextIOBase
-from typing import Any
+from io import SEEK_SET, SEEK_CUR, SEEK_END
+from typing import Any, TextIO
 
 import sublime
 from sublime import Region
@@ -10,7 +10,7 @@ from sublime import Region
 from ._util.guard import define_guard
 
 
-class ViewStream(TextIOBase):
+class ViewStream(TextIO):
     """A :class:`~io.TextIOBase` encapsulating a :class:`~sublime.View` object.
 
     All public methods (except :meth:`flush`) require

--- a/sublime_lib/view_stream.py
+++ b/sublime_lib/view_stream.py
@@ -10,6 +10,48 @@ from sublime import Region
 from ._util.guard import define_guard
 
 
+@define_guard
+@contextmanager
+def guard_read_only(vs: ViewStream) -> Generator[Any, None, None]:
+    if vs.view.is_read_only():
+        if vs.force_writes:
+            vs.view.set_read_only(False)
+            yield
+            vs.view.set_read_only(True)
+        else:
+            raise ValueError("The underlying view is read-only.")
+    else:
+        yield
+
+
+@define_guard
+@contextmanager
+def guard_auto_indent(vs: ViewStream) -> Generator[Any, None, None]:
+    settings = vs.view.settings()
+    if settings.get('auto_indent'):
+        settings.set('auto_indent', False)
+        yield
+        settings.set('auto_indent', True)
+    else:
+        yield
+
+
+@define_guard
+def guard_validity(vs: ViewStream) -> None:
+    if not vs.view.is_valid():
+        raise ValueError("The underlying view is invalid.")
+
+
+@define_guard
+def guard_selection(vs: ViewStream) -> None:
+    if len(vs.view.sel()) == 0:
+        raise ValueError("The underlying view has no selection.")
+    elif len(vs.view.sel()) > 1:
+        raise ValueError("The underlying view has multiple selections.")
+    elif not vs.view.sel()[0].empty():
+        raise ValueError("The underlying view's selection is not empty.")
+
+
 class ViewStream(TextIO):
     """A :class:`~io.TextIOBase` encapsulating a :class:`~sublime.View` object.
 
@@ -34,44 +76,6 @@ class ViewStream(TextIO):
     ..  versionchanged:: 1.2
         Added the `follow_cursor` option.
     """
-
-    @define_guard
-    @contextmanager
-    def guard_read_only(self) -> Generator[Any, None, None]:
-        if self.view.is_read_only():
-            if self.force_writes:
-                self.view.set_read_only(False)
-                yield
-                self.view.set_read_only(True)
-            else:
-                raise ValueError("The underlying view is read-only.")
-        else:
-            yield
-
-    @define_guard
-    @contextmanager
-    def guard_auto_indent(self) -> Generator[Any, None, None]:
-        settings = self.view.settings()
-        if settings.get('auto_indent'):
-            settings.set('auto_indent', False)
-            yield
-            settings.set('auto_indent', True)
-        else:
-            yield
-
-    @define_guard
-    def guard_validity(self) -> None:
-        if not self.view.is_valid():
-            raise ValueError("The underlying view is invalid.")
-
-    @define_guard
-    def guard_selection(self) -> None:
-        if len(self.view.sel()) == 0:
-            raise ValueError("The underlying view has no selection.")
-        elif len(self.view.sel()) > 1:
-            raise ValueError("The underlying view has multiple selections.")
-        elif not self.view.sel()[0].empty():
-            raise ValueError("The underlying view's selection is not empty.")
 
     def __init__(
         self, view: sublime.View, *, force_writes: bool = False, follow_cursor: bool = False

--- a/sublime_lib/view_stream.py
+++ b/sublime_lib/view_stream.py
@@ -136,7 +136,7 @@ class ViewStream(TextIOBase):
 
     def print(self, *objects: object, sep: str = ' ', end: str = '\n') -> None:
         """Shorthand for :func:`print()` passing this ViewStream as the `file` argument."""
-        print(*objects, file=self, sep=sep, end=end)  # type: ignore
+        print(*objects, file=self, sep=sep, end=end)
 
     def flush(self) -> None:
         """Do nothing. (The stream is not buffered.)"""


### PR DESCRIPTION
This required quite a bit of back and forth and I don't exactly consider the result to be readable, but at least it is correct now *and* it did, in fact, reveal another typing bug.

With these changes, we now pass typechecks in mypy 1.19 (which does not support Python 3.8 as defined in our `pyproject.toml` and thus cannot be invoked via `uv`, but it doesn't hurt to be future-proof).